### PR TITLE
feat: Added trust elements - Customers, Mitsui, StraitsTimes, TUVApproved

### DIFF
--- a/packages/docs/liveEditorCode/trustElements/Customers.code.js
+++ b/packages/docs/liveEditorCode/trustElements/Customers.code.js
@@ -1,0 +1,11 @@
+() => {
+  return (
+    <>
+      <Customers
+        title="Over 8 million customers"
+        linkText="Read on Trustpilot"
+        href="https://www.trustpilot.com/review/transferwise.com"
+      />
+    </>
+  )
+};

--- a/packages/docs/liveEditorCode/trustElements/Mitsui.code.js
+++ b/packages/docs/liveEditorCode/trustElements/Mitsui.code.js
@@ -1,0 +1,11 @@
+() => {
+  return (
+    <>
+      <Mitsui
+        title="Mitsui & Co invested in us"
+        linkText="Read on TechCrunch"
+        href="https://jp.techcrunch.com/2017/11/04/20171101transferwise-280-million/"
+      />
+    </>
+  )
+};

--- a/packages/docs/liveEditorCode/trustElements/StraitsTimes.code.js
+++ b/packages/docs/liveEditorCode/trustElements/StraitsTimes.code.js
@@ -1,0 +1,11 @@
+() => {
+  return (
+    <>
+      <StraitsTimes
+        title="Over 8 million customers"
+        linkText="Read on Straits Times"
+        href="https://www.sgsme.sg/news/transferwise-aims-be-next-skype-money-transfers"
+      />
+    </>
+  )
+};

--- a/packages/docs/liveEditorCode/trustElements/TUVApproved.code.js
+++ b/packages/docs/liveEditorCode/trustElements/TUVApproved.code.js
@@ -1,0 +1,11 @@
+() => {
+  return (
+    <>
+      <TUVApproved
+        title="TÜV approved"
+        linkText="The report"
+        href="https://transferwise.com/gb/blog/transferwise-tuv-audit-2019"
+      />
+    </>
+  )
+};

--- a/packages/docs/pages/components/content/trustElements/Customers.mdx
+++ b/packages/docs/pages/components/content/trustElements/Customers.mdx
@@ -1,0 +1,10 @@
+import { LiveEditorBlock, GeneratePropsTable } from '../../../../utils';
+import { Customers } from '@transferwise/marketing-components';
+import code from '../../../../liveEditorCode/trustElements/Customers.code';
+
+<LiveEditorBlock code={code} scope={{ Customers }} />
+<GeneratePropsTable componentName="Customers" />
+
+export const meta = {
+  name: 'Customers',
+};

--- a/packages/docs/pages/components/content/trustElements/Mitsui.mdx
+++ b/packages/docs/pages/components/content/trustElements/Mitsui.mdx
@@ -1,0 +1,10 @@
+import { LiveEditorBlock, GeneratePropsTable } from '../../../../utils';
+import { Mitsui } from '@transferwise/marketing-components';
+import code from '../../../../liveEditorCode/trustElements/Mitsui.code';
+
+<LiveEditorBlock code={code} scope={{ Mitsui }} />
+<GeneratePropsTable componentName="Mitsui" />
+
+export const meta = {
+  name: 'Mitsui',
+};

--- a/packages/docs/pages/components/content/trustElements/StraitsTimes.mdx
+++ b/packages/docs/pages/components/content/trustElements/StraitsTimes.mdx
@@ -1,0 +1,10 @@
+import { LiveEditorBlock, GeneratePropsTable } from '../../../../utils';
+import { StraitsTimes } from '@transferwise/marketing-components';
+import code from '../../../../liveEditorCode/trustElements/StraitsTimes.code';
+
+<LiveEditorBlock code={code} scope={{ StraitsTimes }} />
+<GeneratePropsTable componentName="StraitsTimes" />
+
+export const meta = {
+  name: 'StraitsTimes',
+};

--- a/packages/docs/pages/components/content/trustElements/TUVApproved.mdx
+++ b/packages/docs/pages/components/content/trustElements/TUVApproved.mdx
@@ -1,0 +1,10 @@
+import { LiveEditorBlock, GeneratePropsTable } from '../../../../utils';
+import { TUVApproved } from '@transferwise/marketing-components';
+import code from '../../../../liveEditorCode/trustElements/TUVApproved.code';
+
+<LiveEditorBlock code={code} scope={{ TUVApproved }} />
+<GeneratePropsTable componentName="TUVApproved" />
+
+export const meta = {
+  name: 'TUVApproved',
+};

--- a/packages/marketing-components/src/index.js
+++ b/packages/marketing-components/src/index.js
@@ -1,3 +1,12 @@
 export { default as VideoModal } from './videomodal';
 export { default as YouTubeVideoModal } from './youtubevideomodal';
-export { FCARegulated, Trustpilot, CanstarAward, ASICRegulated } from './trustelements';
+export {
+  ASICRegulated,
+  CanstarAward,
+  Customers,
+  FCARegulated,
+  Mitsui,
+  StraitsTimes,
+  Trustpilot,
+  TUVApproved,
+} from './trustelements';

--- a/packages/marketing-components/src/trustelements/Customers/Customers.js
+++ b/packages/marketing-components/src/trustelements/Customers/Customers.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Types from 'prop-types';
+
+import TrustElement from '../TrustElement';
+
+const Customers = ({ title, linkText, href }) => (
+  <TrustElement
+    src="https://transferwise.com/public-resources/assets/marketing-components/illustrations/customers.svg"
+    title={title}
+    linkText={linkText}
+    href={href}
+  />
+);
+Customers.propTypes = {
+  title: Types.string.isRequired,
+  linkText: Types.string.isRequired,
+  href: Types.string.isRequired,
+};
+
+export default Customers;

--- a/packages/marketing-components/src/trustelements/Customers/index.js
+++ b/packages/marketing-components/src/trustelements/Customers/index.js
@@ -1,0 +1,1 @@
+export { default } from './Customers';

--- a/packages/marketing-components/src/trustelements/Mitsui/Mitsui.js
+++ b/packages/marketing-components/src/trustelements/Mitsui/Mitsui.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Types from 'prop-types';
+
+import TrustElement from '../TrustElement';
+
+const Mitsui = ({ title, linkText, href }) => (
+  <TrustElement
+    src="https://transferwise.com/public-resources/assets/marketing-components/illustrations/mitsui.svg"
+    title={title}
+    linkText={linkText}
+    href={href}
+  />
+);
+Mitsui.propTypes = {
+  title: Types.string.isRequired,
+  linkText: Types.string.isRequired,
+  href: Types.string.isRequired,
+};
+
+export default Mitsui;

--- a/packages/marketing-components/src/trustelements/Mitsui/index.js
+++ b/packages/marketing-components/src/trustelements/Mitsui/index.js
@@ -1,0 +1,1 @@
+export { default } from './Mitsui';

--- a/packages/marketing-components/src/trustelements/StraitsTimes/StraitsTimes.js
+++ b/packages/marketing-components/src/trustelements/StraitsTimes/StraitsTimes.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Types from 'prop-types';
+
+import TrustElement from '../TrustElement';
+
+const StraitsTimes = ({ title, linkText, href }) => (
+  <TrustElement
+    src="https://transferwise.com/public-resources/assets/marketing-components/illustrations/straits_times.svg"
+    title={title}
+    linkText={linkText}
+    href={href}
+  />
+);
+StraitsTimes.propTypes = {
+  title: Types.string.isRequired,
+  linkText: Types.string.isRequired,
+  href: Types.string.isRequired,
+};
+
+export default StraitsTimes;

--- a/packages/marketing-components/src/trustelements/StraitsTimes/index.js
+++ b/packages/marketing-components/src/trustelements/StraitsTimes/index.js
@@ -1,0 +1,1 @@
+export { default } from './StraitsTimes';

--- a/packages/marketing-components/src/trustelements/TUVApproved/TUVApproved.js
+++ b/packages/marketing-components/src/trustelements/TUVApproved/TUVApproved.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Types from 'prop-types';
+
+import TrustElement from '../TrustElement';
+
+const TUVApproved = ({ title, linkText, href }) => (
+  <TrustElement
+    src="https://transferwise.com/public-resources/assets/marketing-components/illustrations/tuv.png"
+    title={title}
+    linkText={linkText}
+    href={href}
+  />
+);
+TUVApproved.propTypes = {
+  title: Types.string.isRequired,
+  linkText: Types.string.isRequired,
+  href: Types.string.isRequired,
+};
+
+export default TUVApproved;

--- a/packages/marketing-components/src/trustelements/TUVApproved/index.js
+++ b/packages/marketing-components/src/trustelements/TUVApproved/index.js
@@ -1,0 +1,1 @@
+export { default } from './TUVApproved';

--- a/packages/marketing-components/src/trustelements/TrustElements.story.js
+++ b/packages/marketing-components/src/trustelements/TrustElements.story.js
@@ -1,58 +1,19 @@
 import React from 'react';
+import {
+  ASICRegulated,
+  CanstarAward,
+  Customers,
+  FCARegulated,
+  Mitsui,
+  StraitsTimes,
+  Trustpilot,
+  TUVApproved,
+} from './';
 import { withKnobs, text } from '@storybook/addon-knobs';
-import { FCARegulated as FCA, CanstarAward as Canstar, Trustpilot, ASICRegulated } from './';
 
 export default {
   title: 'TrustElements',
   decorators: [withKnobs],
-};
-
-export const FCARegulated = () => {
-  return (
-    <div className="row">
-      <div className="col col-xs-offset-4 col-xs-4">
-        <FCA
-          title={text('Title', 'FCA regulated')}
-          linkText={text('LinkText', 'Learn more')}
-          href={text(
-            'Link Url',
-            'https://transferwise.com/help/article/1870573/security/security-and-regulatory-information',
-          )}
-        />
-      </div>
-    </div>
-  );
-};
-
-export const CanstarAward = () => {
-  return (
-    <div className="row">
-      <div className="col col-xs-offset-5 col-xs-2">
-        <Canstar
-          title={text('Title', 'Awarded 5 stars for international money transfers')}
-          linkText={text('LinkText', 'Read the full report')}
-          href={text(
-            'Link Url',
-            'https://transferwise.com/help/article/1870573/security/security-and-regulatory-information',
-          )}
-        />
-      </div>
-    </div>
-  );
-};
-
-export const TrustpilotRating = () => {
-  return (
-    <div className="row">
-      <div className="col col-xs-offset-4 col-xs-4">
-        <Trustpilot
-          title={text('Title', '8 million customers')}
-          linkText={text('LinkText', 'Read on Trustpilot')}
-          href={text('Link Url', 'https://www.trustpilot.com/review/transferwise.com')}
-        />
-      </div>
-    </div>
-  );
 };
 
 export const ASICRegulatedElement = () => {
@@ -66,6 +27,116 @@ export const ASICRegulatedElement = () => {
             'Link Url',
             'https://transferwise.com/help/article/1870573/security/security-and-regulatory-information',
           )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const CanstarAwardTE = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-5 col-xs-2">
+        <CanstarAward
+          title={text('Title', 'Awarded 5 stars for international money transfers')}
+          linkText={text('LinkText', 'Read the full report')}
+          href={text(
+            'Link Url',
+            'https://transferwise.com/help/article/1870573/security/security-and-regulatory-information',
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const CustomersTE = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-4 col-xs-4">
+        <Customers
+          title={text('Title', 'Over 8 million customers')}
+          linkText={text('LinkText', 'Read on Trustpilot')}
+          href={text('Link Url', 'https://www.trustpilot.com/review/transferwise.com')}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const FCARegulatedTE = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-4 col-xs-4">
+        <FCARegulated
+          title={text('Title', 'FCA regulated')}
+          linkText={text('LinkText', 'Learn more')}
+          href={text(
+            'Link Url',
+            'https://transferwise.com/help/article/1870573/security/security-and-regulatory-information',
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const MitsuiTE = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-4 col-xs-4">
+        <Mitsui
+          title={text('Title', 'Mitsui & Co invested in us')}
+          linkText={text('LinkText', 'Read on TechCrunch')}
+          href={text(
+            'Link Url',
+            'https://jp.techcrunch.com/2017/11/04/20171101transferwise-280-million/',
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const StraitsTimesTE = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-4 col-xs-4">
+        <StraitsTimes
+          title={text('Title', 'Over 8 million customers')}
+          linkText={text('LinkText', 'Read on Straits Times')}
+          href={text(
+            'Link Url',
+            'https://www.sgsme.sg/news/transferwise-aims-be-next-skype-money-transfers',
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const TrustpilotTE = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-4 col-xs-4">
+        <Trustpilot
+          title={text('Title', '8 million customers')}
+          linkText={text('LinkText', 'Read on Trustpilot')}
+          href={text('Link Url', 'https://www.trustpilot.com/review/transferwise.com')}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const TUVApprovedTE = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-4 col-xs-4">
+        <TUVApproved
+          title={text('Title', 'TÜV approved')}
+          linkText={text('LinkText', 'The report')}
+          href={text('Link Url', 'https://transferwise.com/gb/blog/transferwise-tuv-audit-2019')}
         />
       </div>
     </div>

--- a/packages/marketing-components/src/trustelements/index.js
+++ b/packages/marketing-components/src/trustelements/index.js
@@ -1,4 +1,8 @@
-export { default as FCARegulated } from './FCARegulated';
-export { default as CanstarAward } from './CanstarAward';
-export { default as Trustpilot } from './Trustpilot';
 export { default as ASICRegulated } from './ASICRegulated';
+export { default as CanstarAward } from './CanstarAward';
+export { default as Customers } from './Customers';
+export { default as FCARegulated } from './FCARegulated';
+export { default as Mitsui } from './Mitsui';
+export { default as StraitsTimes } from './StraitsTimes';
+export { default as Trustpilot } from './Trustpilot';
+export { default as TUVApproved } from './TUVApproved';


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
Extracting the trust elements from home page into marketing components. This PR is just about adding more trust elements.

Once this is merged all that is left is FCA and FPXPay.

## 🚀 Changes

 <!-- What changes have you made? -->
Added the following:
- Customers
- Mitsui
- StraitsTimes
- TUVApproved

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
