### PR TITLE
feat: added Trustpilot component

### DIFF
--- a/packages/docs/liveEditorCode/trustElements/Trustpilot.code.js
+++ b/packages/docs/liveEditorCode/trustElements/Trustpilot.code.js
@@ -1,0 +1,7 @@
+() => (
+    <Trustpilot
+        title="8 million customers"
+        linkText="Read on Trustpilot"
+        href="https://www.trustpilot.com/review/transferwise.com"
+    />
+)

--- a/packages/docs/pages/components/content/trustElements/Trustpilot.mdx
+++ b/packages/docs/pages/components/content/trustElements/Trustpilot.mdx
@@ -1,0 +1,10 @@
+import { LiveEditorBlock, GeneratePropsTable } from '../../../../utils';
+import { Trustpilot } from '@transferwise/marketing-components';
+import code from '../../../../liveEditorCode/trustElements/Trustpilot.code';
+
+<LiveEditorBlock code={code} scope={{ Trustpilot }} />
+<GeneratePropsTable componentName="Trustpilot" />
+
+export const meta = {
+  name: 'Trustpilot',
+};

--- a/packages/marketing-components/src/index.js
+++ b/packages/marketing-components/src/index.js
@@ -1,3 +1,3 @@
 export { default as VideoModal } from './videomodal';
 export { default as YouTubeVideoModal } from './youtubevideomodal';
-export { FCARegulated } from './trustelements';
+export { FCARegulated, Trustpilot } from './trustelements';

--- a/packages/marketing-components/src/trustelements/README.md
+++ b/packages/marketing-components/src/trustelements/README.md
@@ -1,0 +1,32 @@
+## Static Images
+
+Static images should be uploaded to the [static assets](https://github.com/transferwise/marketing-components/tree/main/packages/marketing-components/src/trustelements) repo and referenced in the component.
+
+example:
+
+```
+    <TrustElement
+        src="https://transferwise.com/public-resources/assets/marketing-components/illustrations/FCA.svg"
+        title={title}
+        linkText={linkText}
+        href={href}
+    />
+```
+
+------
+
+## Animated Svgs
+
+In case of Animated Svgs create the Svg illustration as a react component and pass the same as src. `shouldAnimate` flag **should** be true in order to render the Svg as React component.
+
+example:
+
+```
+    <TrustElement
+        src={YourReactComponent}
+        title={title}
+        linkText={linkText}
+        href={href}
+        shouldAnimate
+    />
+```

--- a/packages/marketing-components/src/trustelements/TrustElement/TrustElement.js
+++ b/packages/marketing-components/src/trustelements/TrustElement/TrustElement.js
@@ -47,7 +47,7 @@ const TrustElement = ({ title, alt, linkText, href, src, shouldAnimate }) => {
 const isAnchorUrl = (url) => url[0] === '#';
 
 TrustElement.propTypes = {
-  src: Types.node.isRequired,
+  src: Types.oneOfType([Types.element, Types.string]).isRequired,
   alt: Types.string,
   title: Types.string.isRequired,
   linkText: Types.string,

--- a/packages/marketing-components/src/trustelements/TrustElement/TrustElement.js
+++ b/packages/marketing-components/src/trustelements/TrustElement/TrustElement.js
@@ -22,9 +22,7 @@ const TrustElement = ({ title, alt, linkText, href, src, shouldAnimate }) => {
       data-testid="trust-element-container"
     >
       {shouldAnimate ? (
-        <div className="tw-trust-element__svg_container">
-          <img className="tw-trust-element__image" src={src} alt={alt} />
-        </div>
+        <div className="tw-trust-element__svg_container">{src}</div>
       ) : (
         <img className="tw-trust-element__image" src={src} alt={alt} />
       )}
@@ -49,7 +47,7 @@ const TrustElement = ({ title, alt, linkText, href, src, shouldAnimate }) => {
 const isAnchorUrl = (url) => url[0] === '#';
 
 TrustElement.propTypes = {
-  src: Types.string.isRequired,
+  src: Types.node.isRequired,
   alt: Types.string,
   title: Types.string.isRequired,
   linkText: Types.string,

--- a/packages/marketing-components/src/trustelements/TrustElement/TrustElement.spec.js
+++ b/packages/marketing-components/src/trustelements/TrustElement/TrustElement.spec.js
@@ -2,6 +2,13 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import TrustElement from './TrustElement';
 
+const SvgAsComponent = (
+  <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <title>Svg as component</title>
+    <circle cx="50" cy="50" r="50" />
+  </svg>
+);
+
 describe('Trust Element', () => {
   it('should not add the animate css initially', () => {
     const { getByTestId } = render(
@@ -116,5 +123,19 @@ describe('Trust Element', () => {
     );
 
     expect(queryByText('linkText').target).toBe('_blank');
+  });
+
+  it('renders the svg as component', () => {
+    const { queryByTitle } = render(
+      <TrustElement
+        src={SvgAsComponent}
+        title="title"
+        linkText="linkText"
+        href="#some-id"
+        shouldAnimate
+      />,
+    );
+
+    expect(queryByTitle('Svg as component')).toBeInTheDocument();
   });
 });

--- a/packages/marketing-components/src/trustelements/TrustElements.story.js
+++ b/packages/marketing-components/src/trustelements/TrustElements.story.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { FCARegulated as FCA } from './';
 import { withKnobs, text } from '@storybook/addon-knobs';
+import { FCARegulated as FCA, Trustpilot } from './';
 
 export default {
   title: 'TrustElements',
@@ -18,6 +18,20 @@ export const FCARegulated = () => {
             'Link Url',
             'https://transferwise.com/help/article/1870573/security/security-and-regulatory-information',
           )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const TrustpilotRating = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-4 col-xs-4">
+        <Trustpilot
+          title={text('Title', '8 million customers')}
+          linkText={text('LinkText', 'Read on Trustpilot')}
+          href={text('Link Url', 'https://www.trustpilot.com/review/transferwise.com')}
         />
       </div>
     </div>

--- a/packages/marketing-components/src/trustelements/Trustpilot/Trustpilot.js
+++ b/packages/marketing-components/src/trustelements/Trustpilot/Trustpilot.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import Types from 'prop-types';
+
+import TrustElement from '../TrustElement';
+import TrustpilotIllustration from './TrustpilotIllustration';
+
+const Trustpilot = ({ title, linkText, href }) => (
+  <TrustElement
+    src={<TrustpilotIllustration />}
+    title={title}
+    linkText={linkText}
+    href={href}
+    shouldAnimate
+  />
+);
+
+Trustpilot.propTypes = {
+  title: Types.string.isRequired,
+  linkText: Types.string.isRequired,
+  href: Types.string.isRequired,
+};
+export default Trustpilot;

--- a/packages/marketing-components/src/trustelements/Trustpilot/TrustpilotIllustration.js
+++ b/packages/marketing-components/src/trustelements/Trustpilot/TrustpilotIllustration.js
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import './TrustpilotIllustration.css';
+
+const TrustpilotIllustration = () => (
+  <svg
+    id="el_H8G--UHWO"
+    className="tw-trust-element__image"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 84 50"
+  >
+    <path d="M14.3 43.5h46.9v-21H0v21h7.1V50l7.2-6.5z" id="el_o50-IfnOhY" />
+    <g id="el_ZKUtuKmlJ2_an_27_VJB_eK" data-animator-group="true" data-animator-type="2">
+      <path d="M70.1 38.5H7.2v-24h77.2v24h-7.1V45l-7.2-6.5z" id="el_ZKUtuKmlJ2" />
+    </g>
+    <g id="el_cKmWEw9KDj_an_Al496FKhj" data-animator-group="true" data-animator-type="2">
+      <path
+        d="M24 25.5h-3.2l-1-3-1 3h-3.2l2.6 1.9-1 3.1 2.6-1.9 2.6 1.9-1-3.1 2.6-1.9z"
+        id="el_cKmWEw9KDj"
+      />
+    </g>
+    <g id="el_FrN2weN1HV_an_VyY4hnoQje" data-animator-group="true" data-animator-type="2">
+      <path
+        id="el_FrN2weN1HV"
+        d="M37 25.5h-3.2l-1-3-1 3h-3.2l2.6 1.9-1 3.1 2.6-1.9 2.6 1.9-1-3.1z"
+      />
+    </g>
+    <g id="el_QxWDtUDnYN_an_fi3jS4kw1" data-animator-group="true" data-animator-type="2">
+      <path
+        id="el_QxWDtUDnYN"
+        d="M50 25.5h-3.2l-1-3-1 3h-3.2l2.6 1.9-1 3.1 2.6-1.9 2.6 1.9-1-3.1 2.6-1.9z"
+      />
+    </g>
+    <g id="el_0LSJko48lh_an_2TS1w_u6J" data-animator-group="true" data-animator-type="2">
+      <path
+        id="el_0LSJko48lh"
+        d="M63 25.5h-3.2l-1-3-1 3h-3.2l2.6 1.9-1 3.1 2.6-1.9 2.6 1.9-1-3.1 2.6-1.9z"
+      />
+    </g>
+    <g id="el_Yv2r1TIYxk_an_GdS0Y6cG7" data-animator-group="true" data-animator-type="2">
+      <path
+        id="el_Yv2r1TIYxk"
+        d="M76 25.5h-3.2l-1-3-1 3h-3.2l2.6 1.9-1 3.1 2.6-1.9 2.6 1.9-1-3.1 2.6-1.9z"
+      />
+    </g>
+  </svg>
+);
+
+export default TrustpilotIllustration;

--- a/packages/marketing-components/src/trustelements/Trustpilot/TrustpilotIllustration.less
+++ b/packages/marketing-components/src/trustelements/Trustpilot/TrustpilotIllustration.less
@@ -1,0 +1,830 @@
+.tw-trust-element {
+    #el_H8G--UHWO * {
+      -webkit-animation-duration: 3s;
+      animation-duration: 3s;
+      -webkit-animation-iteration-count: 1;
+      animation-iteration-count: 1;
+      -webkit-animation-play-state: running;
+      animation-play-state: running;
+      -webkit-animation-timing-function: cubic-bezier(0, 0, 1, 1);
+      animation-timing-function: cubic-bezier(0, 0, 1, 1);
+    }
+    #el_o50-IfnOhY {
+      fill: #253655;
+    }
+    #el_ZKUtuKmlJ2 {
+      fill: #dbf4fe;
+    }
+    #el_FrN2weN1HV,
+    #el_cKmWEw9KDj {
+      fill: #485cc7;
+      -webkit-animation-fill-mode: backwards;
+      animation-fill-mode: backwards;
+      opacity: 1;
+      -webkit-animation-timing-function: cubic-bezier(0, 0, 1, 1);
+      animation-timing-function: cubic-bezier(0, 0, 1, 1);
+    }
+  
+    #el_0LSJko48lh,
+    #el_FrN2weN1HV_an_VyY4hnoQje,
+    #el_QxWDtUDnYN,
+    #el_Yv2r1TIYxk,
+    #el_ZKUtuKmlJ2_an_27_VJB_eK,
+    #el_cKmWEw9KDj_an_Al496FKhj {
+      -webkit-animation-fill-mode: backwards;
+      animation-fill-mode: backwards;
+      -webkit-animation-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
+      animation-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
+    }
+    #el_0LSJko48lh,
+    #el_QxWDtUDnYN,
+    #el_Yv2r1TIYxk {
+      fill: #485cc7;
+      opacity: 1;
+    }
+  
+    #el_FrN2weN1HV_an_VyY4hnoQje,
+    #el_ZKUtuKmlJ2_an_27_VJB_eK,
+    #el_cKmWEw9KDj_an_Al496FKhj {
+      -webkit-transform: translate(45.79999828338623px, 29.75px) scale(0.9, 0.9)
+        translate(-45.79999828338623px, -29.75px);
+      transform: translate(45.79999828338623px, 29.75px) scale(0.9, 0.9)
+        translate(-45.79999828338623px, -29.75px);
+    }
+  
+    #el_FrN2weN1HV_an_VyY4hnoQje,
+    #el_cKmWEw9KDj_an_Al496FKhj {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+      -webkit-animation-timing-function: cubic-bezier(0, 0, 1, 1);
+      animation-timing-function: cubic-bezier(0, 0, 1, 1);
+    }
+  
+    #el_FrN2weN1HV_an_VyY4hnoQje {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+    }
+  
+    #el_0LSJko48lh_an_2TS1w_u6J,
+    #el_QxWDtUDnYN_an_fi3jS4kw1,
+    #el_Yv2r1TIYxk_an_GdS0Y6cG7 {
+      -webkit-animation-fill-mode: backwards;
+      animation-fill-mode: backwards;
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+      -webkit-animation-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
+      animation-timing-function: cubic-bezier(0.42, 0, 0.58, 1);
+    }
+  
+    #el_0LSJko48lh_an_2TS1w_u6J,
+    #el_Yv2r1TIYxk_an_GdS0Y6cG7 {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+    }
+  
+    #el_Yv2r1TIYxk_an_GdS0Y6cG7 {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+    }
+  
+    &-animate {
+      #el_H8G--UHWO #el_cKmWEw9KDj {
+        -webkit-animation-name: kf_el_cKmWEw9KDj_an_jFs68S90u;
+        animation-name: kf_el_cKmWEw9KDj_an_jFs68S90u;
+      }
+      #el_H8G--UHWO #el_FrN2weN1HV {
+        -webkit-animation-name: kf_el_FrN2weN1HV_an_Iv1XzXcLb;
+        animation-name: kf_el_FrN2weN1HV_an_Iv1XzXcLb;
+      }
+      #el_H8G--UHWO #el_QxWDtUDnYN {
+        -webkit-animation-name: kf_el_QxWDtUDnYN_an_r0ls01Rqv;
+        animation-name: kf_el_QxWDtUDnYN_an_r0ls01Rqv;
+      }
+      #el_H8G--UHWO #el_0LSJko48lh {
+        -webkit-animation-name: kf_el_0LSJko48lh_an_fzYuChVyV;
+        animation-name: kf_el_0LSJko48lh_an_fzYuChVyV;
+      }
+      #el_H8G--UHWO #el_Yv2r1TIYxk {
+        -webkit-animation-name: kf_el_Yv2r1TIYxk_an_OC_NQFURmu;
+        animation-name: kf_el_Yv2r1TIYxk_an_OC_NQFURmu;
+      }
+      #el_H8G--UHWO #el_ZKUtuKmlJ2_an_27_VJB_eK {
+        -webkit-animation-name: kf_el_ZKUtuKmlJ2_an_27_VJB_eK;
+        animation-name: kf_el_ZKUtuKmlJ2_an_27_VJB_eK;
+      }
+      #el_H8G--UHWO #el_cKmWEw9KDj_an_Al496FKhj {
+        -webkit-animation-name: kf_el_cKmWEw9KDj_an_Al496FKhj;
+        animation-name: kf_el_cKmWEw9KDj_an_Al496FKhj;
+      }
+      #el_H8G--UHWO #el_FrN2weN1HV_an_VyY4hnoQje {
+        -webkit-animation-name: kf_el_FrN2weN1HV_an_VyY4hnoQje;
+        animation-name: kf_el_FrN2weN1HV_an_VyY4hnoQje;
+      }
+      #el_H8G--UHWO #el_QxWDtUDnYN_an_fi3jS4kw1 {
+        -webkit-animation-name: kf_el_QxWDtUDnYN_an_fi3jS4kw1;
+        animation-name: kf_el_QxWDtUDnYN_an_fi3jS4kw1;
+      }
+      #el_H8G--UHWO #el_0LSJko48lh_an_2TS1w_u6J {
+        -webkit-animation-name: kf_el_0LSJko48lh_an_2TS1w_u6J;
+        animation-name: kf_el_0LSJko48lh_an_2TS1w_u6J;
+      }
+      #el_H8G--UHWO #el_Yv2r1TIYxk_an_GdS0Y6cG7 {
+        -webkit-animation-name: kf_el_Yv2r1TIYxk_an_GdS0Y6cG7;
+        animation-name: kf_el_Yv2r1TIYxk_an_GdS0Y6cG7;
+      }
+    }
+  }
+  
+  @-webkit-keyframes kf_el_Aah-uEJoYX_an_ziBxRrW_i {
+    0%,
+    70%,
+    to {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+    }
+    53.33% {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(0, 0)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(0, 0)
+        translate(-71.79999923706055px, -26.5px);
+    }
+    66.67% {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-71.79999923706055px, -26.5px);
+    }
+  }
+  @keyframes kf_el_Aah-uEJoYX_an_ziBxRrW_i {
+    0%,
+    70%,
+    to {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+    }
+    53.33% {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(0, 0)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(0, 0)
+        translate(-71.79999923706055px, -26.5px);
+    }
+    66.67% {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-71.79999923706055px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_Aah-uEJoYX_an_zKmUbVFRI {
+    0%,
+    66.67%,
+    to {
+      opacity: 1;
+    }
+    2.22%,
+    53.33% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_Aah-uEJoYX_an_zKmUbVFRI {
+    0%,
+    66.67%,
+    to {
+      opacity: 1;
+    }
+    2.22%,
+    53.33% {
+      opacity: 0;
+    }
+  }
+  @-webkit-keyframes kf_el_qdAoDH9IPR_an_dEeMkwJZp {
+    0%,
+    56.67%,
+    to {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+    }
+    40% {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(0, 0)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(0, 0)
+        translate(-58.79999923706055px, -26.5px);
+    }
+    53.33% {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-58.79999923706055px, -26.5px);
+    }
+  }
+  @keyframes kf_el_qdAoDH9IPR_an_dEeMkwJZp {
+    0%,
+    56.67%,
+    to {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+    }
+    40% {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(0, 0)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(0, 0)
+        translate(-58.79999923706055px, -26.5px);
+    }
+    53.33% {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-58.79999923706055px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_qdAoDH9IPR_an_ZNpcvtXX3 {
+    0%,
+    53.33%,
+    to {
+      opacity: 1;
+    }
+    2.22%,
+    40% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_qdAoDH9IPR_an_ZNpcvtXX3 {
+    0%,
+    53.33%,
+    to {
+      opacity: 1;
+    }
+    2.22%,
+    40% {
+      opacity: 0;
+    }
+  }
+  @-webkit-keyframes kf_el_xMegQK2ZDf_an_fObUtvL2Y {
+    0%,
+    43.33%,
+    to {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+    }
+    26.67% {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(0, 0)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(0, 0)
+        translate(-45.79999923706055px, -26.5px);
+    }
+    40% {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-45.79999923706055px, -26.5px);
+    }
+  }
+  @keyframes kf_el_xMegQK2ZDf_an_fObUtvL2Y {
+    0%,
+    43.33%,
+    to {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+    }
+    26.67% {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(0, 0)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(0, 0)
+        translate(-45.79999923706055px, -26.5px);
+    }
+    40% {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(1.1, 1.1)
+        translate(-45.79999923706055px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_xMegQK2ZDf_an_HG2z-M-jr {
+    0%,
+    40%,
+    to {
+      opacity: 1;
+    }
+    2.22%,
+    26.67% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_xMegQK2ZDf_an_HG2z-M-jr {
+    0%,
+    40%,
+    to {
+      opacity: 1;
+    }
+    2.22%,
+    26.67% {
+      opacity: 0;
+    }
+  }
+  @-webkit-keyframes kf_el_cXjMPQr6FC_an_S0WGMYt3w {
+    0%,
+    30%,
+    to {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+    }
+    13.33% {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(0, 0)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(0, 0)
+        translate(-32.80000019073486px, -26.5px);
+    }
+    26.67% {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(1.1, 1.1)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(1.1, 1.1)
+        translate(-32.80000019073486px, -26.5px);
+    }
+  }
+  @keyframes kf_el_cXjMPQr6FC_an_S0WGMYt3w {
+    0%,
+    30%,
+    to {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+    }
+    13.33% {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(0, 0)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(0, 0)
+        translate(-32.80000019073486px, -26.5px);
+    }
+    26.67% {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(1.1, 1.1)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(1.1, 1.1)
+        translate(-32.80000019073486px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_cXjMPQr6FC_an_aHb42KkpR {
+    0%,
+    26.67%,
+    to {
+      opacity: 1;
+    }
+    13.33%,
+    2.22% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_cXjMPQr6FC_an_aHb42KkpR {
+    0%,
+    26.67%,
+    to {
+      opacity: 1;
+    }
+    13.33%,
+    2.22% {
+      opacity: 0;
+    }
+  }
+  @-webkit-keyframes kf_el_EJegLN07op_an_tlXyvj1Oo {
+    0%,
+    16.67%,
+    to {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+    }
+    2.22% {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(0, 0)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(0, 0)
+        translate(-19.799999713897705px, -26.5px);
+    }
+    13.33% {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(1.1, 1.1)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(1.1, 1.1)
+        translate(-19.799999713897705px, -26.5px);
+    }
+  }
+  @keyframes kf_el_EJegLN07op_an_tlXyvj1Oo {
+    0%,
+    16.67%,
+    to {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+    }
+    2.22% {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(0, 0)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(0, 0)
+        translate(-19.799999713897705px, -26.5px);
+    }
+    13.33% {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(1.1, 1.1)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(1.1, 1.1)
+        translate(-19.799999713897705px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_EJegLN07op_an_eYMT4dnOd {
+    0%,
+    13.33%,
+    to {
+      opacity: 1;
+    }
+    2.22% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_EJegLN07op_an_eYMT4dnOd {
+    0%,
+    13.33%,
+    to {
+      opacity: 1;
+    }
+    2.22% {
+      opacity: 0;
+    }
+  }
+  
+  @-webkit-keyframes kf_el_Yv2r1TIYxk_an_OC_NQFURmu {
+    0%,
+    34.44%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_Yv2r1TIYxk_an_OC_NQFURmu {
+    0%,
+    34.44%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @-webkit-keyframes kf_el_Yv2r1TIYxk_an_GdS0Y6cG7 {
+    0%,
+    38.89%,
+    to {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(0, 0)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(0, 0)
+        translate(-71.79999923706055px, -26.5px);
+    }
+    34.44% {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-71.79999923706055px, -26.5px);
+    }
+  }
+  @keyframes kf_el_Yv2r1TIYxk_an_GdS0Y6cG7 {
+    0%,
+    38.89%,
+    to {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(1, 1)
+        translate(-71.79999923706055px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(0, 0)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(0, 0)
+        translate(-71.79999923706055px, -26.5px);
+    }
+    34.44% {
+      -webkit-transform: translate(71.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-71.79999923706055px, -26.5px);
+      transform: translate(71.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-71.79999923706055px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_0LSJko48lh_an_2TS1w_u6J {
+    0%,
+    34.44%,
+    to {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(0, 0)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(0, 0)
+        translate(-58.79999923706055px, -26.5px);
+    }
+    30% {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-58.79999923706055px, -26.5px);
+    }
+  }
+  @keyframes kf_el_0LSJko48lh_an_2TS1w_u6J {
+    0%,
+    34.44%,
+    to {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(1, 1)
+        translate(-58.79999923706055px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(0, 0)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(0, 0)
+        translate(-58.79999923706055px, -26.5px);
+    }
+    30% {
+      -webkit-transform: translate(58.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-58.79999923706055px, -26.5px);
+      transform: translate(58.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-58.79999923706055px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_0LSJko48lh_an_fzYuChVyV {
+    0%,
+    30%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_0LSJko48lh_an_fzYuChVyV {
+    0%,
+    30%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @-webkit-keyframes kf_el_QxWDtUDnYN_an_r0ls01Rqv {
+    0%,
+    25.56%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_QxWDtUDnYN_an_r0ls01Rqv {
+    0%,
+    25.56%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @-webkit-keyframes kf_el_QxWDtUDnYN_an_fi3jS4kw1 {
+    0%,
+    30%,
+    to {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(0, 0)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(0, 0)
+        translate(-45.79999923706055px, -26.5px);
+    }
+    25.56% {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-45.79999923706055px, -26.5px);
+    }
+  }
+  @keyframes kf_el_QxWDtUDnYN_an_fi3jS4kw1 {
+    0%,
+    30%,
+    to {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(1, 1)
+        translate(-45.79999923706055px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(0, 0)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(0, 0)
+        translate(-45.79999923706055px, -26.5px);
+    }
+    25.56% {
+      -webkit-transform: translate(45.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-45.79999923706055px, -26.5px);
+      transform: translate(45.79999923706055px, 26.5px) scale(1.8, 1.8)
+        translate(-45.79999923706055px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_FrN2weN1HV_an_VyY4hnoQje {
+    0%,
+    25.56%,
+    to {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(0, 0)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(0, 0)
+        translate(-32.80000019073486px, -26.5px);
+    }
+    21.11% {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(1.8, 1.8)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(1.8, 1.8)
+        translate(-32.80000019073486px, -26.5px);
+    }
+  }
+  @keyframes kf_el_FrN2weN1HV_an_VyY4hnoQje {
+    0%,
+    25.56%,
+    to {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(1, 1)
+        translate(-32.80000019073486px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(0, 0)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(0, 0)
+        translate(-32.80000019073486px, -26.5px);
+    }
+    21.11% {
+      -webkit-transform: translate(32.80000019073486px, 26.5px) scale(1.8, 1.8)
+        translate(-32.80000019073486px, -26.5px);
+      transform: translate(32.80000019073486px, 26.5px) scale(1.8, 1.8)
+        translate(-32.80000019073486px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_FrN2weN1HV_an_Iv1XzXcLb {
+    0%,
+    21.11%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_FrN2weN1HV_an_Iv1XzXcLb {
+    0%,
+    21.11%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @-webkit-keyframes kf_el_cKmWEw9KDj_an_Al496FKhj {
+    0%,
+    21.11%,
+    to {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(0, 0)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(0, 0)
+        translate(-19.799999713897705px, -26.5px);
+    }
+    16.67% {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(1.8, 1.8)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(1.8, 1.8)
+        translate(-19.799999713897705px, -26.5px);
+    }
+  }
+  @keyframes kf_el_cKmWEw9KDj_an_Al496FKhj {
+    0%,
+    21.11%,
+    to {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(1, 1)
+        translate(-19.799999713897705px, -26.5px);
+    }
+    5.56% {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(0, 0)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(0, 0)
+        translate(-19.799999713897705px, -26.5px);
+    }
+    16.67% {
+      -webkit-transform: translate(19.799999713897705px, 26.5px) scale(1.8, 1.8)
+        translate(-19.799999713897705px, -26.5px);
+      transform: translate(19.799999713897705px, 26.5px) scale(1.8, 1.8)
+        translate(-19.799999713897705px, -26.5px);
+    }
+  }
+  @-webkit-keyframes kf_el_cKmWEw9KDj_an_jFs68S90u {
+    0%,
+    16.67%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @keyframes kf_el_cKmWEw9KDj_an_jFs68S90u {
+    0%,
+    16.67%,
+    to {
+      opacity: 1;
+    }
+    5.56% {
+      opacity: 0;
+    }
+  }
+  @-webkit-keyframes kf_el_ZKUtuKmlJ2_an_27_VJB_eK {
+    0%,
+    50%,
+    61.11%,
+    to {
+      -webkit-transform: translate(45.79999828338623px, 29.75px) scale(0.9, 0.9)
+        translate(-45.79999828338623px, -29.75px);
+      transform: translate(45.79999828338623px, 29.75px) scale(0.9, 0.9)
+        translate(-45.79999828338623px, -29.75px);
+    }
+    55.56% {
+      -webkit-transform: translate(45.79999828338623px, 29.75px) scale(1, 1)
+        translate(-45.79999828338623px, -29.75px);
+      transform: translate(45.79999828338623px, 29.75px) scale(1, 1)
+        translate(-45.79999828338623px, -29.75px);
+    }
+  }
+  @keyframes kf_el_ZKUtuKmlJ2_an_27_VJB_eK {
+    0%,
+    50%,
+    61.11%,
+    to {
+      -webkit-transform: translate(45.79999828338623px, 29.75px) scale(0.9, 0.9)
+        translate(-45.79999828338623px, -29.75px);
+      transform: translate(45.79999828338623px, 29.75px) scale(0.9, 0.9)
+        translate(-45.79999828338623px, -29.75px);
+    }
+    55.56% {
+      -webkit-transform: translate(45.79999828338623px, 29.75px) scale(1, 1)
+        translate(-45.79999828338623px, -29.75px);
+      transform: translate(45.79999828338623px, 29.75px) scale(1, 1)
+        translate(-45.79999828338623px, -29.75px);
+    }
+  }

--- a/packages/marketing-components/src/trustelements/Trustpilot/index.js
+++ b/packages/marketing-components/src/trustelements/Trustpilot/index.js
@@ -1,0 +1,1 @@
+export { default } from './Trustpilot';

--- a/packages/marketing-components/src/trustelements/index.js
+++ b/packages/marketing-components/src/trustelements/index.js
@@ -1,1 +1,2 @@
 export { default as FCARegulated } from './FCARegulated';
+export { default as Trustpilot } from './Trustpilot';


### PR DESCRIPTION
## 🖼 Context

Adds a new marketing component. Trustpilot
## 🚀 Changes

Modified the TrustElement component to render the SVG image that's passed as a react component

## 🤔 Considerations

Even though svg can now be passed as component, it will be rendered only if the `shouldAnimate` is true. I left this condition as it is, so that the the images that does not require animation can come via `static-assets`. 

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
