### PR TITLE
feat: Added Canstar award trustelement 

### DIFF
--- a/packages/docs/liveEditorCode/trustElements/CanstarAward.code.js
+++ b/packages/docs/liveEditorCode/trustElements/CanstarAward.code.js
@@ -1,0 +1,11 @@
+() => {
+    return (
+        <>
+            <CanstarAward
+            title="Awarded 5 stars for international money transfers"
+            linkText="Read the full report"
+            href="https://transferwise.com/help/article/1870573/security/security-and-regulatory-information"
+            />
+        </>
+    )
+};

--- a/packages/docs/pages/components/content/trustElements/CanstarAward.mdx
+++ b/packages/docs/pages/components/content/trustElements/CanstarAward.mdx
@@ -1,0 +1,10 @@
+import { LiveEditorBlock, GeneratePropsTable } from '../../../../utils';
+import { CanstarAward } from '@transferwise/marketing-components';
+import code from '../../../../liveEditorCode/trustElements/CanstarAward.code';
+
+<LiveEditorBlock code={code} scope={{ CanstarAward }} />
+<GeneratePropsTable componentName="CanstarAward" />
+
+export const meta = {
+  name: 'Canstar Award',
+};

--- a/packages/marketing-components/src/index.js
+++ b/packages/marketing-components/src/index.js
@@ -1,3 +1,3 @@
 export { default as VideoModal } from './videomodal';
 export { default as YouTubeVideoModal } from './youtubevideomodal';
-export { FCARegulated, Trustpilot } from './trustelements';
+export { FCARegulated, Trustpilot, CanstarAward } from './trustelements';

--- a/packages/marketing-components/src/trustelements/CanstarAward/CanstarAward.js
+++ b/packages/marketing-components/src/trustelements/CanstarAward/CanstarAward.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Types from 'prop-types';
+
+import TrustElement from '../TrustElement';
+
+const CanstarAward = ({ title, linkText, href }) => (
+  <TrustElement
+    src="https://transferwise.com/public-resources/assets/marketing-components/illustrations/canstar.png"
+    title={title}
+    linkText={linkText}
+    href={href}
+  />
+);
+CanstarAward.propTypes = {
+  title: Types.string.isRequired,
+  linkText: Types.string.isRequired,
+  href: Types.string.isRequired,
+};
+
+export default CanstarAward;

--- a/packages/marketing-components/src/trustelements/CanstarAward/index.js
+++ b/packages/marketing-components/src/trustelements/CanstarAward/index.js
@@ -1,0 +1,1 @@
+export { default } from './CanstarAward';

--- a/packages/marketing-components/src/trustelements/TrustElements.story.js
+++ b/packages/marketing-components/src/trustelements/TrustElements.story.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { withKnobs, text } from '@storybook/addon-knobs';
-import { FCARegulated as FCA, Trustpilot } from './';
+import { FCARegulated as FCA, CanstarAward as Canstar, Trustpilot } from './';
 
 export default {
   title: 'TrustElements',
@@ -14,6 +14,23 @@ export const FCARegulated = () => {
         <FCA
           title={text('Title', 'FCA regulated')}
           linkText={text('LinkText', 'Learn more')}
+          href={text(
+            'Link Url',
+            'https://transferwise.com/help/article/1870573/security/security-and-regulatory-information',
+          )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const CanstarAward = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-5 col-xs-2">
+        <Canstar
+          title={text('Title', 'Awarded 5 stars for international money transfers')}
+          linkText={text('LinkText', 'Read the full report')}
           href={text(
             'Link Url',
             'https://transferwise.com/help/article/1870573/security/security-and-regulatory-information',

--- a/packages/marketing-components/src/trustelements/index.js
+++ b/packages/marketing-components/src/trustelements/index.js
@@ -1,2 +1,3 @@
 export { default as FCARegulated } from './FCARegulated';
+export { default as CanstarAward } from './CanstarAward';
 export { default as Trustpilot } from './Trustpilot';


### PR DESCRIPTION
## 🖼 Context

Extracting trustelements from homepage to marketing-component.

## 🚀 Changes

Adding a new trust element for the Canstar award 

## ✅ Checklist

- [X] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [X] Changes are tested and all tests pass
- [X] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [X] You've updated the documentation if necessary
