### PR TITLE
chore: remove DS from codeowners

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-☝ This title will appear in the changelog - keep it meaningful and follow [the commit lint format](https://github.com/transferwise/marketing-components/blob/main/CONTRIBUTING.md#versioning-and-commit-lint).
-
 ## 🖼 Context
 
 <!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
@@ -14,6 +12,7 @@
 
 ## ✅ Checklist
 
+- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
 - [ ] Changes are tested and all tests pass
 - [ ] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
 - [ ] Changes work in all supported browsers (don't forget IE11)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+☝ This title will appear in the changelog - keep it meaningful and follow [the commit lint format](https://github.com/transferwise/marketing-components/blob/main/CONTRIBUTING.md#versioning-and-commit-lint).
+
 ## 🖼 Context
 
 <!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
@@ -12,7 +14,6 @@
 
 ## ✅ Checklist
 
-- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
 - [ ] Changes are tested and all tests pass
 - [ ] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
 - [ ] Changes work in all supported browsers (don't forget IE11)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @transferwise/conversion @transferwise/organic-growth @transferwise/design-system
+* @transferwise/conversion @transferwise/organic-growth


### PR DESCRIPTION
Reverts the change made in transferwise/marketing-components#7 to make the DS team code owners. We don't need to be code owners of this repo.