### PR TITLE
fix: Removed spacing below svg container for TrustElements

### DIFF
--- a/packages/marketing-components/src/trustelements/TrustElement/TrustElement.less
+++ b/packages/marketing-components/src/trustelements/TrustElement/TrustElement.less
@@ -13,6 +13,7 @@
   max-width: 80px;
   object-fit: contain;
   display: inline-block;
+  vertical-align: top;
 }
 .tw-trust-element .link-callout {
   text-decoration: none;


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
Getting some misalignments. It seems that display: inline-block comes likes to add spacings.
https://stackoverflow.com/questions/10612380/get-rid-of-space-underneath-inline-block-image
<img width="503" alt="Screenshot 2020-10-05 at 15 42 15" src="https://user-images.githubusercontent.com/52004834/95094088-684b1b80-0721-11eb-8214-cdbafc2db24f.png">

## 🚀 Changes

 <!-- What changes have you made? -->
Add `vertical-align: top;`to the sag container for trust elements

<img width="501" alt="Screenshot 2020-10-05 at 15 44 15" src="https://user-images.githubusercontent.com/52004834/95094313-acd6b700-0721-11eb-8ab2-cbdcd7ea03b2.png">


## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
