### PR TITLE
feat: Added InstaMoney trust element

### DIFF
--- a/packages/docs/liveEditorCode/trustElements/InstaMoney.code.js
+++ b/packages/docs/liveEditorCode/trustElements/InstaMoney.code.js
@@ -1,0 +1,11 @@
+() => {
+  return (
+    <>
+      <InstaMoney
+        title="Powered by Instamoney"
+        linkText="Learn More"
+        href="https://www.instamoney.co/"
+      />
+    </>
+  );
+};

--- a/packages/docs/pages/components/content/trustElements/InstaMoney.mdx
+++ b/packages/docs/pages/components/content/trustElements/InstaMoney.mdx
@@ -1,0 +1,10 @@
+import { LiveEditorBlock, GeneratePropsTable } from '../../../../utils';
+import { InstaMoney } from '@transferwise/marketing-components';
+import code from '../../../../liveEditorCode/trustElements/InstaMoney.code';
+
+<LiveEditorBlock code={code} scope={{ InstaMoney }} />
+<GeneratePropsTable componentName="InstaMoney" />
+
+export const meta = {
+  name: 'InstaMoney',
+};

--- a/packages/marketing-components/src/index.js
+++ b/packages/marketing-components/src/index.js
@@ -12,6 +12,7 @@ export {
   FCARegulated,
   FINTRACRegulated,
   FSRAApproved,
+  InstaMoney,
   JPFSARegulated,
   MASRegulated,
   Mitsui,

--- a/packages/marketing-components/src/trustelements/InstaMoney/InstaMoney.js
+++ b/packages/marketing-components/src/trustelements/InstaMoney/InstaMoney.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Types from 'prop-types';
+
+import TrustElement from '../TrustElement';
+
+const InstaMoney = ({ title, linkText, href }) => (
+  <TrustElement
+    src="https://transferwise.com/public-resources/assets/marketing-components/illustrations/instamoney.png"
+    title={title}
+    linkText={linkText}
+    href={href}
+  />
+);
+
+InstaMoney.propTypes = {
+  title: Types.string.isRequired,
+  linkText: Types.string.isRequired,
+  href: Types.string.isRequired,
+};
+
+export default InstaMoney;

--- a/packages/marketing-components/src/trustelements/InstaMoney/index.js
+++ b/packages/marketing-components/src/trustelements/InstaMoney/index.js
@@ -1,0 +1,1 @@
+export { default } from './InstaMoney';

--- a/packages/marketing-components/src/trustelements/TrustElements.story.js
+++ b/packages/marketing-components/src/trustelements/TrustElements.story.js
@@ -12,6 +12,7 @@ import {
   FCARegulated,
   FINTRACRegulated,
   FSRAApproved,
+  InstaMoney,
   JPFSARegulated,
   MASRegulated,
   Mitsui,
@@ -203,6 +204,20 @@ export const FSRAApprovedElement = () => {
             'Link Url',
             'https://transferwise.com/help/article/1870573/security/security-and-regulatory-information',
           )}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const InstaMoneyElement = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-4 col-xs-4">
+        <InstaMoney
+          title={text('Title', 'Powered by Instamoney')}
+          linkText={text('LinkText', 'Learn more')}
+          href={text('Link Url', 'https://www.instamoney.co/')}
         />
       </div>
     </div>

--- a/packages/marketing-components/src/trustelements/index.js
+++ b/packages/marketing-components/src/trustelements/index.js
@@ -9,6 +9,7 @@ export { default as DIARegulated } from './DIARegulated';
 export { default as FCARegulated } from './FCARegulated';
 export { default as FINTRACRegulated } from './FINTRACRegulated';
 export { default as FSRAApproved } from './FSRAApproved';
+export { default as InstaMoney } from './InstaMoney';
 export { default as JPFSARegulated } from './JPFSARegulated';
 export { default as MASRegulated } from './MASRegulated';
 export { default as Mitsui } from './Mitsui';


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
Extracting trust elements from homepage to marketing-components so that homepage and referral-pages can use it.

Forgot one last TrustElement, InstaMoney.

## 🚀 Changes

 <!-- What changes have you made? -->
Add InstaMoney component and documentation

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
