### PR TITLE
feat!: bumping major version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,9 @@ The rules are simple:
 - If you are fixing something, use `fix`. This will bump the patch version.
 - If you are adding a new feature, use `feat`. This will bump the minor version.
 - If you are committing a breaking change, add a ! after the type: `feat!: this is a breaking change`
-  - Also add `BREAKING CHANGE: <your breaking change>` as a description
+  - Also add `BREAKING CHANGE: <your breaking change>` in the PR description when you merge
+    <img src="https://user-images.githubusercontent.com/1204500/95431469-1c78bc00-0945-11eb-96b8-d8372e5c0802.png"
+         style="height: 200px;" />
 
 Using anything other than `fix` or `feat` without a `!` will not trigger a version bump. This is useful for changes to CI config, documentation or tests. Feel free to choose the type that best reflects the work you're doing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ The rules are simple:
 - If you are fixing something, use `fix`. This will bump the patch version.
 - If you are adding a new feature, use `feat`. This will bump the minor version.
 - If you are committing a breaking change, add a ! after the type: `feat!: this is a breaking change`
-  - Also add `BREAKING CHANGE` as first words in description
+  - Also add `BREAKING CHANGE: <your breaking change>` as a description
 
 Using anything other than `fix` or `feat` without a `!` will not trigger a version bump. This is useful for changes to CI config, documentation or tests. Feel free to choose the type that best reflects the work you're doing.
 

--- a/packages/marketing-components/src/trustelements/TrustElements.story.js
+++ b/packages/marketing-components/src/trustelements/TrustElements.story.js
@@ -226,7 +226,7 @@ export const InstaMoney = () => {
     <div className="row">
       <span>
         <b>
-          NOTE: The background colour is needed to highlight the image. Not part of the component
+          NOTE: The background colour is needed to highlight the image. Not part of the component.
         </b>
       </span>
       <br />
@@ -280,7 +280,7 @@ export const Mitsui = () => {
     <div className="row">
       <span>
         <b>
-          NOTE: The background colour is needed to highlight the image. Not part of the component
+          NOTE: The background colour is needed to highlight the image. Not part of the component.
         </b>
       </span>
       <br />
@@ -322,7 +322,7 @@ export const StraitsTimes = () => {
     <div className="row">
       <span>
         <b>
-          NOTE: The background colour is needed to highlight the image. Not part of the component
+          NOTE: The background colour is needed to highlight the image. Not part of the component.
         </b>
       </span>
       <br />
@@ -391,7 +391,7 @@ export const FPXPay = () => {
     <div className="row">
       <span>
         <b>
-          NOTE: The background colour is needed to highlight the image. Not part of the component
+          NOTE: The background colour is needed to highlight the image. Not part of the component.
         </b>
       </span>
       <br />


### PR DESCRIPTION
## 🖼 Context

2 last times major version bumps failed. Hopefully this is the one

## 🚀 Changes

 Random change so we can get a major version bump. Previous change was adding `TrustElement` to trust element names

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
