### PR TITLE
fix: allow passing elements as props for trust elements

### DIFF
--- a/packages/marketing-components/src/trustelements/ASICRegulatedTrustElement/ASICRegulatedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/ASICRegulatedTrustElement/ASICRegulatedTrustElement.js
@@ -16,8 +16,8 @@ const ASICRegulatedTrustElement = ({ title, linkText, href, useIllustration }) =
 );
 
 ASICRegulatedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/BNMApprovedTrustElement/BNMApprovedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/BNMApprovedTrustElement/BNMApprovedTrustElement.js
@@ -16,8 +16,8 @@ const BNMApprovedTrustElement = ({ title, linkText, href, useIllustration }) => 
 );
 
 BNMApprovedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/BirlesikOdemeRegulatedTrustElement/BirlesikOdemeRegulatedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/BirlesikOdemeRegulatedTrustElement/BirlesikOdemeRegulatedTrustElement.js
@@ -16,14 +16,16 @@ const BirlesikOdemeRegulatedTrustElement = ({ title, linkText, href, useIllustra
 );
 
 BirlesikOdemeRegulatedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
-  href: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]),
+  href: Types.string,
   useIllustration: Types.bool,
 };
 
 BirlesikOdemeRegulatedTrustElement.defaultProps = {
   useIllustration: true,
+  linkText: null,
+  href: null,
 };
 
 export default BirlesikOdemeRegulatedTrustElement;

--- a/packages/marketing-components/src/trustelements/BrazilianCorrespondentTrustElement/BrazilianCorrespondentTrustElement.js
+++ b/packages/marketing-components/src/trustelements/BrazilianCorrespondentTrustElement/BrazilianCorrespondentTrustElement.js
@@ -16,8 +16,8 @@ const BrazilianCorrespondentTrustElement = ({ title, linkText, href, useIllustra
 );
 
 BrazilianCorrespondentTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/CAndEDRegulatedTrustElement/CAndEDRegulatedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/CAndEDRegulatedTrustElement/CAndEDRegulatedTrustElement.js
@@ -16,8 +16,8 @@ const CAndEDRegulatedTrustElement = ({ title, linkText, href, useIllustration })
 );
 
 CAndEDRegulatedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/CanstarAwardTrustElement/CanstarAwardTrustElement.js
+++ b/packages/marketing-components/src/trustelements/CanstarAwardTrustElement/CanstarAwardTrustElement.js
@@ -14,8 +14,8 @@ const CanstarAwardTrustElement = ({ title, linkText, href, useIllustration }) =>
 );
 
 CanstarAwardTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/CustomersTrustElement/CustomersTrustElement.js
+++ b/packages/marketing-components/src/trustelements/CustomersTrustElement/CustomersTrustElement.js
@@ -14,8 +14,8 @@ const CustomersTrustElement = ({ title, linkText, href, useIllustration }) => (
 );
 
 CustomersTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/DIARegulatedTrustElement/DIARegulatedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/DIARegulatedTrustElement/DIARegulatedTrustElement.js
@@ -16,8 +16,8 @@ const DIARegulatedTrustElement = ({ title, linkText, href, useIllustration }) =>
 );
 
 DIARegulatedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/FCARegulatedTrustElement/FCARegulatedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/FCARegulatedTrustElement/FCARegulatedTrustElement.js
@@ -14,8 +14,8 @@ const FCARegulatedTrustElement = ({ title, linkText, href, useIllustration }) =>
 );
 
 FCARegulatedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/FINTRACRegulatedTrustElement/FINTRACRegulatedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/FINTRACRegulatedTrustElement/FINTRACRegulatedTrustElement.js
@@ -16,8 +16,8 @@ const FINTRACRegulatedTrustElement = ({ title, linkText, href, useIllustration }
 );
 
 FINTRACRegulatedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/FPXPayTrustElement/FPXPayTrustElement.js
+++ b/packages/marketing-components/src/trustelements/FPXPayTrustElement/FPXPayTrustElement.js
@@ -15,10 +15,10 @@ const FPXPayTrustElement = ({ title, linkText, href, alt, useIllustration }) => 
 );
 
 FPXPayTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
-  alt: Types.string,
+  alt: Types.oneOfType([Types.element, Types.string]),
   useIllustration: Types.bool,
 };
 

--- a/packages/marketing-components/src/trustelements/FSRAApprovedTrustElement/FSRAApprovedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/FSRAApprovedTrustElement/FSRAApprovedTrustElement.js
@@ -14,8 +14,8 @@ const FSRAApprovedTrustElement = ({ title, linkText, href, useIllustration }) =>
 );
 
 FSRAApprovedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/InstaMoneyTrustElement/InstaMoneyTrustElement.js
+++ b/packages/marketing-components/src/trustelements/InstaMoneyTrustElement/InstaMoneyTrustElement.js
@@ -14,8 +14,8 @@ const InstaMoneyTrustElement = ({ title, linkText, href, useIllustration }) => (
 );
 
 InstaMoneyTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/JPFSARegulatedTrustElement/JPFSARegulatedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/JPFSARegulatedTrustElement/JPFSARegulatedTrustElement.js
@@ -16,8 +16,8 @@ const JPFSARegulatedTrustElement = ({ title, linkText, href, useIllustration }) 
 );
 
 JPFSARegulatedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/MASRegulatedTrustElement/MASRegulatedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/MASRegulatedTrustElement/MASRegulatedTrustElement.js
@@ -16,8 +16,8 @@ const MASRegulatedTrustElement = ({ title, linkText, href, useIllustration }) =>
 );
 
 MASRegulatedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/MitsuiTrustElement/MitsuiTrustElement.js
+++ b/packages/marketing-components/src/trustelements/MitsuiTrustElement/MitsuiTrustElement.js
@@ -14,8 +14,8 @@ const MitsuiTrustElement = ({ title, linkText, href, useIllustration }) => (
 );
 
 MitsuiTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/SafeTrustElement/SafeTrustElement.js
+++ b/packages/marketing-components/src/trustelements/SafeTrustElement/SafeTrustElement.js
@@ -16,8 +16,8 @@ const SafeTrustElement = ({ title, linkText, href, useIllustration }) => (
 );
 
 SafeTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/StraitsTimesTrustElement/StraitsTimesTrustElement.js
+++ b/packages/marketing-components/src/trustelements/StraitsTimesTrustElement/StraitsTimesTrustElement.js
@@ -14,8 +14,8 @@ const StraitsTimesTrustElement = ({ title, linkText, href, useIllustration }) =>
 );
 
 StraitsTimesTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/TUVApprovedTrustElement/TUVApprovedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/TUVApprovedTrustElement/TUVApprovedTrustElement.js
@@ -14,8 +14,8 @@ const TUVApprovedTrustElement = ({ title, linkText, href, useIllustration }) => 
 );
 
 TUVApprovedTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/TrustElement/TrustElement.js
+++ b/packages/marketing-components/src/trustelements/TrustElement/TrustElement.js
@@ -61,9 +61,9 @@ const TrustElement = ({ title, alt, linkText, href, src, shouldAnimate, useIllus
 
 TrustElement.propTypes = {
   src: Types.oneOfType([Types.element, Types.string]).isRequired,
-  alt: Types.string,
-  title: Types.string.isRequired,
-  linkText: Types.string,
+  alt: Types.oneOfType([Types.element, Types.string]),
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]),
   href: Types.string,
   shouldAnimate: Types.bool,
   useIllustration: Types.bool,

--- a/packages/marketing-components/src/trustelements/TrustpilotTrustElement/TrustpilotTrustElement.js
+++ b/packages/marketing-components/src/trustelements/TrustpilotTrustElement/TrustpilotTrustElement.js
@@ -16,8 +16,8 @@ const TrustpilotTrustElement = ({ title, linkText, href, useIllustration }) => (
 );
 
 TrustpilotTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };

--- a/packages/marketing-components/src/trustelements/TrustpilotUsTrustElement/TrustpilotUSTrustElement.js
+++ b/packages/marketing-components/src/trustelements/TrustpilotUsTrustElement/TrustpilotUSTrustElement.js
@@ -16,8 +16,8 @@ const TrustpilotUSTrustElement = ({ title, linkText, href, useIllustration }) =>
 );
 
 TrustpilotUSTrustElement.propTypes = {
-  title: Types.string.isRequired,
-  linkText: Types.string.isRequired,
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
   href: Types.string.isRequired,
   useIllustration: Types.bool,
 };


### PR DESCRIPTION
## 🖼 Context

Before you can only pass strings for `title` etc but now we can also pass elements eg. `<Message>translated.string</Message>`.

## 🚀 Changes

Allow passing elements along with strings for `title`, `linkText` and `alt`.

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
