### PR TITLE
chore: Update CODEOWNERS to have a single marketing-components superteam as reviewers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,3 +17,4 @@
 - [ ] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
 - [ ] Changes work in all supported browsers (don't forget IE11)
 - [ ] You've updated the documentation if necessary
+- [ ] Change has been approved by someone outside of your team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @transferwise/conversion @transferwise/organic-growth
+* @transferwise/marketing-components


### PR DESCRIPTION
## 🖼 Context
Currently CRs are required from both Conversion + OG teams.

## 🚀 Changes
By creating a trusted '[Marketing Components](https://github.com/orgs/transferwise/teams/marketing-components/members)' team, we can reduce the friction in contributing by only requiring a single reviewer to approve. That reviewer should come from outside of the team and a check box added to the PR template to try and remind every one!

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary