### PR TITLE
feat: Add cookie consent to YouTubeVideoModal

### DIFF
--- a/packages/docs/pages/components/content/YouTubeVideoModal.mdx
+++ b/packages/docs/pages/components/content/YouTubeVideoModal.mdx
@@ -10,6 +10,8 @@ Used on [transferwise.com](https://transferwise.com).
 
 **Note:** To use this component in your application, you need to install [neptune-css](https://transferwise.github.io/neptune-web/about/Setup) and [@transferwise/icons@1.5.0](https://github.com/transferwise/icons)
 
+**Note v2:** This component respects cookie consent and if customer has not accepted it then video is opened in a new tab instead of opening it in a modal. [Read more why we need to do this](https://transferwise.atlassian.net/wiki/spaces/C20/pages/1115621535/How+to+make+your+application+compliant+with+ICO+regulations)
+
 <LiveEditorBlock code={code} scope={{ YouTubeVideoModal }} />
 <GeneratePropsTable componentName="YouTubeVideoModal" />
 

--- a/packages/marketing-components/package.json
+++ b/packages/marketing-components/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@babel/runtime": "^7.9.2",
     "@reach/dialog": "^0.10.5",
+    "@transferwise/cookie-consent": "^2.8.0",
     "classnames": "^2.2.6",
     "react-spring": "^8.0.27"
   },

--- a/packages/marketing-components/src/youtubevideomodal/YouTubeVideoModal.js
+++ b/packages/marketing-components/src/youtubevideomodal/YouTubeVideoModal.js
@@ -7,15 +7,14 @@ import VideoModal from '../videomodal';
 const YouTubeVideoModal = ({ videoId, posterUrl, translations, isOpen, onDismiss, ...rest }) => {
   const posterFallbackUrl = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
   const videoUrl = `https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&html5=1&rel=0&showinfo=0&autoplay=1&wmode=opaque`;
-  let isVideoModalOpen = false;
 
-  if (isOpen) {
-    if (hasValidConsent()) {
-      isVideoModalOpen = true;
-    } else if (typeof window !== 'undefined') {
+  if (!hasValidConsent()) {
+    if (isOpen && typeof window !== 'undefined') {
       window.open(`https://youtu.be/${videoId}`, '_blank');
       onDismiss();
     }
+
+    return null;
   }
 
   return (
@@ -23,7 +22,7 @@ const YouTubeVideoModal = ({ videoId, posterUrl, translations, isOpen, onDismiss
       {...rest}
       posterUrl={posterUrl || posterFallbackUrl}
       translations={translations}
-      isOpen={isVideoModalOpen}
+      isOpen={isOpen}
       onDismiss={onDismiss}
     >
       <iframe

--- a/packages/marketing-components/src/youtubevideomodal/YouTubeVideoModal.js
+++ b/packages/marketing-components/src/youtubevideomodal/YouTubeVideoModal.js
@@ -1,14 +1,31 @@
 import React from 'react';
 import Types from 'prop-types';
+import { hasValidConsent } from '@transferwise/cookie-consent';
 
 import VideoModal from '../videomodal';
 
-const YouTubeVideoModal = ({ videoId, posterUrl, translations, ...rest }) => {
+const YouTubeVideoModal = ({ videoId, posterUrl, translations, isOpen, onDismiss, ...rest }) => {
   const posterFallbackUrl = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
   const videoUrl = `https://www.youtube-nocookie.com/embed/${videoId}?enablejsapi=1&html5=1&rel=0&showinfo=0&autoplay=1&wmode=opaque`;
+  let isVideoModalOpen = false;
+
+  if (isOpen) {
+    if (hasValidConsent()) {
+      isVideoModalOpen = true;
+    } else if (typeof window !== 'undefined') {
+      window.open(`https://youtu.be/${videoId}`, '_blank');
+      onDismiss();
+    }
+  }
 
   return (
-    <VideoModal {...rest} posterUrl={posterUrl || posterFallbackUrl} translations={translations}>
+    <VideoModal
+      {...rest}
+      posterUrl={posterUrl || posterFallbackUrl}
+      translations={translations}
+      isOpen={isVideoModalOpen}
+      onDismiss={onDismiss}
+    >
       <iframe
         title={translations.title}
         src={videoUrl}
@@ -32,10 +49,13 @@ YouTubeVideoModal.propTypes = {
       alt: Types.string.isRequired,
     }),
   }).isRequired,
+  onDismiss: Types.func.isRequired,
+  isOpen: Types.bool,
 };
 
 YouTubeVideoModal.defaultProps = {
   posterUrl: '',
+  isOpen: false,
 };
 
 export default YouTubeVideoModal;

--- a/packages/marketing-components/src/youtubevideomodal/YouTubeVideoModal.spec.js
+++ b/packages/marketing-components/src/youtubevideomodal/YouTubeVideoModal.spec.js
@@ -3,8 +3,13 @@ import '@testing-library/jest-dom';
 import { render, act } from '@testing-library/react';
 import createMockRaf from 'mock-raf';
 import { Globals } from 'react-spring';
+import { hasValidConsent } from '@transferwise/cookie-consent';
 
 import YouTubeVideoModal from './';
+
+jest.mock('@transferwise/cookie-consent', () => ({
+  hasValidConsent: jest.fn(),
+}));
 
 const Translations = {
   title: 'Video',
@@ -18,6 +23,8 @@ const Translations = {
 
 describe('YouTubeVideoModal', () => {
   it('renders the fallback poster', () => {
+    hasValidConsent.mockReturnValue(true);
+
     const { getByAltText } = render(
       <YouTubeVideoModal
         translations={Translations}
@@ -36,6 +43,8 @@ describe('YouTubeVideoModal', () => {
   });
 
   it('renders given poster', () => {
+    hasValidConsent.mockReturnValue(true);
+
     const { getByAltText } = render(
       <YouTubeVideoModal
         translations={Translations}
@@ -56,7 +65,8 @@ describe('YouTubeVideoModal', () => {
     );
   });
 
-  it('renders the YouTube video', () => {
+  it('renders the YouTube video if we have cookie consent', () => {
+    hasValidConsent.mockReturnValue(true);
     const mockRaf = createMockRaf();
 
     Globals.injectFrame(mockRaf.raf, mockRaf.cancel);
@@ -84,5 +94,28 @@ describe('YouTubeVideoModal', () => {
     expect(video.src).toBe(
       'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ?enablejsapi=1&html5=1&rel=0&showinfo=0&autoplay=1&wmode=opaque',
     );
+  });
+
+  it('opens YouTube video on other tab if we do not have cookie consent', () => {
+    hasValidConsent.mockReturnValue(false);
+    Object.defineProperty(window, 'open', { value: jest.fn(), writable: true });
+
+    expect(window.open).not.toHaveBeenCalled();
+
+    const { getByAltText } = render(
+      <YouTubeVideoModal
+        translations={Translations}
+        posterUrl="https://transferwise.com/staticrab/homepage/_next/static/images/customer_support-b76c1fb78a1a6239725688ae629ee3e7.jpg"
+        videoId="dQw4w9WgXcQ"
+        onDismiss={() => {}}
+        aria-labelledby="#elm"
+        isOpen
+      >
+        <span>children</span>
+      </YouTubeVideoModal>,
+    );
+
+    expect(() => getByAltText(/poster/i)).toThrow();
+    expect(window.open).toHaveBeenCalledWith(`https://youtu.be/dQw4w9WgXcQ`, '_blank');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3724,6 +3724,11 @@
   dependencies:
     "@babel/runtime" "^7.10.2"
 
+"@transferwise/cookie-consent@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@transferwise/cookie-consent/-/cookie-consent-2.8.0.tgz#75b58476a9e8fa79c824f8ffd47b75bdbea90c3d"
+  integrity sha512-3AD/unNYYmXjsMeEOL70h46pPf6UsAodGtAUgK1Fdnpmz09xg3TDzR/ImWTe608zIIYmCLgKv3Dq6QMxQDX8qQ==
+
 "@transferwise/eslint-config@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@transferwise/eslint-config/-/eslint-config-6.0.0.tgz#c053282f83a456194d7441c7481b448c64ca49f1"
@@ -12410,22 +12415,29 @@ kind-of@^2.0.1:
   dependencies:
     is-buffer "^1.0.2"
 
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
   dependencies:
     is-buffer "^1.1.5"
 
-kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
-  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
+  dependencies:
+    is-buffer "^1.1.5"
 
-kind-of@^5.0.2:
+kind-of@^5.0.0, kind-of@^5.0.2:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
   integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+
+kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 klaw@^1.0.0:
   version "1.3.1"


### PR DESCRIPTION
## 🖼 Context

We need to make sure that everybody who uses `YouTubeVideoModal` will respect the cookie consent.

## 🚀 Changes

YouTube video opens up in a new tab if you don't have cookie consent

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
- [x] Change has been approved by someone outside of your team
