### PR TITLE
Allow static next gh pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ lerna-debug.log
 # CSS
 dist
 *.css
+!**/_next/static/css/**
 packages/css/pages/styles
 
 # docs

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,18 @@
       "allowBranch": "main",
       "conventionalCommits": true,
       "verifyAccess": false,
-      "ignoreChanges": ["**/*.md", "**/*.spec.js", "**/*.yml", "packages/docs"]
+      "ignoreChanges": [
+        "**/*.md",
+        "**/*.spec.js",
+        "**/*.yml",
+        "**/*.story.js",
+        "**/.storybook/**",
+        "**/test/**",
+        "packages/docs",
+        "lerna.json",
+        "**/CODEOWNERS",
+        "**/.gitignore"
+      ]
     }
   },
   "npmClient": "yarn",


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->
- Our github .gitignore contains a rule *.css that means that no css can be committed and pushed. 
- When running deploy-docs gh-pages needs to be able to push the _next css but because of this rule no css can be deployed.
- I'm not entirely sure how did that happend but the gh-pages .gitignore was different from the main one. This can be potentially due to the fact that gh-pages was created before that rule *.css was introduced but not sure.
- If we'll ever recreate gh-pages from main this rule will be part of .gitignore in gh-pages
## 🚀 Changes

 <!-- What changes have you made? -->
Add exception for _next/css

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/neptune-web/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
