### PR TITLE
OG-3646 Add css package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "neptune",
+  "name": "marketing-components",
   "repository": {
     "type": "git",
     "fullname": "transferwise/marketing-components",
@@ -31,9 +31,9 @@
     "@commitlint/config-conventional": "^8.3.4",
     "@transferwise/eslint-config": "^6.0.0",
     "@transferwise/files-scaffold": "^1.0.1",
-    "@transferwise/neptune-tokens": "^0.1.0",
+    "@transferwise/neptune-tokens": "^1.0.0",
     "@transferwise/icons": "^2.4.1",
-    "@transferwise/neptune-css": "^2.1.2",
+    "@transferwise/neptune-css": "^4.0.5",
     "eslint": "^6.8.0",
     "eslint-config-react-app": "^5.2.1",
     "eslint-loader": "^4.0.0",

--- a/packages/css/.eslintrc
+++ b/packages/css/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": "../../.eslintrc",
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  },
+  "globals": {
+    "React": "writable"
+  }
+}

--- a/packages/css/.gulp.json
+++ b/packages/css/.gulp.json
@@ -1,0 +1,5 @@
+{
+  "flags": {
+    "gulpfile": "../../node_modules/@transferwise/less-config/gulpfile.js"
+  }
+}

--- a/packages/css/CONTRIBUTING.md
+++ b/packages/css/CONTRIBUTING.md
@@ -33,7 +33,7 @@ To embed a live code example and demo, you can use the `LiveCodeEditor`. Add the
 
 ```js
 // liveCodeEditor/button.code.js
-<Button onClick={() => alert('clicked')}>I'm a pretty buton</Button>
+<Button onClick={() => alert('clicked')}>I'm a pretty button</Button>
 ```
 
 You can then use it in your page as follows:

--- a/packages/css/CONTRIBUTING.md
+++ b/packages/css/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Please start by reading the [general contribution guide](https://github.com/transferwise/marketing-components/blob/main/CONTRIBUTING.md) to get set up and familiarise yourself with our process. Then read on for specific information about working with the Components.
+
+# Get started
+
+To run the docs environment, work **from the root of the monorepo**, not from here. This is because the docs require the other packages to be built.
+
+Before you start, ensure you've run `yarn setup`. This will ensure that all packages are built (e.g. the CSS that some components use from the `css` package). Then run `docs`:
+
+```
+yarn setup
+yarn docs
+```
+
+This will start the development environment. Changes you make inside `docs` will be live reloaded. If you make a change in another package, you'll have to stop and run `yarn docs` again.
+
+## All available commands
+
+The following commands can be run from inside `docs`:
+
+- `build` - builds the docs (builds of all other packages must have also been executed for this to be useful)
+- `lint` - lints pages
+- `lint:fix` - lints pages and fixes any errors that can be automatically fixed
+
+As a reminder: to load the docs, run `docs` **from the root of the monorepo**, not from here.
+
+# Adding documentation
+
+Each page in the documentation is represented by an [`.mdx`](https://mdxjs.com) file in `pages`. To add a new page, add a new file in the section you'd like it to appear in.
+
+To embed a live code example and demo, you can use the `LiveCodeEditor`. Add the code sample to a new file in the `liveCodeEditor` folder:
+
+```js
+// liveCodeEditor/button.code.js
+<Button onClick={() => alert('clicked')}>I'm a pretty buton</Button>
+```
+
+You can then use it in your page as follows:
+
+```jsx
+// pages/components/Button.mdx
+import { LiveEditorBlock } from '../../utils';
+import { Button } from '@transferwise/marketing-components';
+import code from '../../liveEditorCode/button.code';
+
+<LiveEditorBlock code={code} scope={{ Button }} />;
+```
+
+You can generate a table of supported component props using the `GeneratePropsTable` utility.
+
+```jsx
+// pages/components/Button.mdx
+import { GeneratePropsTable } from '../../utils';
+
+<GeneratePropsTable componentName="Button" />;
+```
+
+This will read the component PropTypes and generate a table showing what is supported and the defaults.

--- a/packages/css/LICENSE.md
+++ b/packages/css/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2020 TransferWise Ltd.
+ 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -5,7 +5,7 @@
 Marketing CSS Components are meant to use in combination with <a href="https://transferwise.github.io/neptune-web/styles">Neptune-css</a>
 Learn <a href="https://transferwise.github.io/neptune-web/about/Styles"> here the basics</a>.
 
-These components are particularly used in public marketing pages and some of them have been deprecated from general `�neptune-css` bundle, which has a product orientation.
+These components are particularly used in public marketing pages and some of them have been deprecated from general `neptune-css` bundle, which has a product orientation.
 
 Other components, as the `Grid Layout` system, it's brand new for marketing purposes, a lightweight simple way to create layouts. This system doesn't support IE11 so take that into account when you have to take decisions.
 

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -1,3 +1,3 @@
 [![CircleCI](https://circleci.com/gh/transferwise/neptune-web.svg?style=shield)](https://circleci.com/gh/transferwise/neptune-web) [![NPM](https://badge.fury.io/js/%40transferwise%2Fneptune-css.svg)](https://www.npmjs.com/package/@transferwise/neptune-css)
 
-# Markeging CSS
+# Marketing CSS

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -1,0 +1,3 @@
+[![CircleCI](https://circleci.com/gh/transferwise/neptune-web.svg?style=shield)](https://circleci.com/gh/transferwise/neptune-web) [![NPM](https://badge.fury.io/js/%40transferwise%2Fneptune-css.svg)](https://www.npmjs.com/package/@transferwise/neptune-css)
+
+# Markeging CSS

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -1,3 +1,30 @@
-[![CircleCI](https://circleci.com/gh/transferwise/neptune-web.svg?style=shield)](https://circleci.com/gh/transferwise/neptune-web) [![NPM](https://badge.fury.io/js/%40transferwise%2Fneptune-css.svg)](https://www.npmjs.com/package/@transferwise/neptune-css)
+[![CircleCI](https://circleci.com/gh/transferwise/marketing-components.svg?style=shield)](https://circleci.com/gh/transferwise/marketing-components) [![NPM](https://badge.fury.io/js/%40transferwise%2Fmarketing-css.svg)](https://www.npmjs.com/package/@transferwise/marketing-css)
 
 # Marketing CSS
+
+Marketing CSS Components are meant to use in combination with <a href="https://transferwise.github.io/neptune-web/styles">Neptune-css</a>
+Learn <a href="https://transferwise.github.io/neptune-web/about/Styles"> here the basics</a>.
+
+These components are particularly used in public marketing pages and some of them have been deprecated from general `�neptune-css` bundle, which has a product orientation.
+
+Other components, as the `Grid Layout` system, it's brand new for marketing purposes, a lightweight simple way to create layouts. This system doesn't support IE11 so take that into account when you have to take decisions.
+
+## Usage
+
+Marketing CSS components are published to npm as [@transferwise/marketing-css](https://www.npmjs.com/package/@transferwise/marketing-css).
+
+Install `@transferwise/marketing-css` and its peer dependencies.
+
+```
+# yarn
+yarn add @transferwise/marketing-css 
+
+# npm
+npm install @transferwise/marketing-css 
+```
+
+The components are ready to import individually in your CSS or compile process (webpack/gulp/...)
+
+```
+import '@transferwise/marketing-css/dist/css/grid-layout.css';
+```

--- a/packages/css/linkFolder.js
+++ b/packages/css/linkFolder.js
@@ -1,4 +1,0 @@
-const path = require('path');
-const { spawn } = require('child_process');
-
-spawn('ln', ['-s', `${path.resolve('../docs')}/pages/styles`, `${__dirname}/pages`]);

--- a/packages/css/linkFolder.js
+++ b/packages/css/linkFolder.js
@@ -1,0 +1,4 @@
+const path = require('path');
+const { spawn } = require('child_process');
+
+spawn('ln', ['-s', `${path.resolve('../docs')}/pages/styles`, `${__dirname}/pages`]);

--- a/packages/css/next.config.js
+++ b/packages/css/next.config.js
@@ -1,0 +1,7 @@
+const withMDX = require('@next/mdx')({
+  extension: /\.mdx?$/,
+});
+
+module.exports = withMDX({
+  pageExtensions: ['js', 'jsx', 'mdx'],
+});

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -28,7 +28,6 @@
     "build:compile-less": "gulp compileLess --src='src/less'",
     "build:compile-deprecated": "gulp compileLess --src='src/less/deprecated' --dest='dist/css/deprecated'",
     "dev": "npm-run-all --parallel dev:*",
-    "dev:link": "node ./linkFolder.js",
     "dev:less": "gulp watchLess --src='src/less/**'",
     "dev:next": "next dev",
     "docs": "yarn build",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -43,14 +43,16 @@
   },
   "devDependencies": {
     "@next/mdx": "^9.0.5",
-    "@transferwise/neptune-css": "^4.0.5",
-    "@transferwise/less-config": "^3.0.0",
     "@zeit/next-css": "^1.0.1",
     "next": "^9.3.2",
     "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "yargs": "^15.3.1"
+  },
+  "peerDependencies": {
+    "@transferwise/neptune-css": "^4.0.5",
+    "@transferwise/less-config": "^3.0.0"
   },
   "resolutions": {
     "svgo": "1.3.2",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@next/mdx": "^9.0.5",
+    "@transferwise/neptune-css": "^4.0.5",
     "@transferwise/less-config": "^3.0.0",
     "@zeit/next-css": "^1.0.1",
     "next": "^9.3.2",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@transferwise/marketing-css",
+  "description": "Marketing CSS is part of TransferWise's Design System CSS library",
+  "version": "1.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "fullname": "transferwise/marketing-components",
+    "url": "git+https://github.com/transferwise/marketing-components.git"
+  },
+  "keywords": [],
+  "author": {
+    "name": "TransferWise",
+    "url": "https://transferwise.com/"
+  },
+  "bugs": {
+    "url": "https://github.com/transferwise/marketing-components/issues"
+  },
+  "homepage": "https://transferwise.github.io/marketing-components",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "npm-run-all build:*",
+    "build:clean": "rm -rf dist",
+    "build:copy-assets": "npm-run-all --parallel copy:*",
+    "build:compile-less": "gulp compileLess --src='src/less'",
+    "build:compile-deprecated": "gulp compileLess --src='src/less/deprecated' --dest='dist/css/deprecated'",
+    "dev": "npm-run-all --parallel dev:*",
+    "dev:link": "node ./linkFolder.js",
+    "dev:less": "gulp watchLess --src='src/less/**'",
+    "dev:next": "next dev",
+    "docs": "yarn build",
+    "copy:images": "cpx 'src/img/**' dist/img",
+    "prettier": "prettier --write src/less/*.less",
+    "lintless": "stylelint ./src/less",
+    "lintless:fix": "yarn lintless --fix"
+  },
+  "dependencies": {
+    "prism-react-renderer": "^1.1.1",
+    "svgo": "1.3.2"
+  },
+  "devDependencies": {
+    "@next/mdx": "^9.0.5",
+    "@transferwise/less-config": "^3.0.0",
+    "@zeit/next-css": "^1.0.1",
+    "next": "^9.3.2",
+    "prop-types": "^15.7.2",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
+    "yargs": "^15.3.1"
+  },
+  "resolutions": {
+    "svgo": "1.3.2",
+    "next/**/kind-of": "^6.0.3"
+  }
+}

--- a/packages/css/pages/_app.js
+++ b/packages/css/pages/_app.js
@@ -1,0 +1,23 @@
+import '../dist/css/neptune.css';
+import './app.css';
+
+import { useRouter } from 'next/router';
+
+// eslint-disable-next-line
+function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+
+  return (
+    <div>
+      {router.pathname !== '/' && (
+        <div className="docs-header">
+          <a href="/">Back to menu</a>
+          <h1>{router.query.name}</h1>
+        </div>
+      )}
+      <Component {...pageProps} />
+    </div>
+  );
+}
+
+export default MyApp;

--- a/packages/css/pages/_app.js
+++ b/packages/css/pages/_app.js
@@ -1,4 +1,3 @@
-import '../dist/css/neptune.css';
 import './app.css';
 
 import { useRouter } from 'next/router';

--- a/packages/css/pages/app.css
+++ b/packages/css/pages/app.css
@@ -1,0 +1,90 @@
+.home {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+
+  min-height: 100vh;
+}
+
+main {
+  display: flex;
+  align-items: center;
+  flex: 1 0 0;
+  flex-direction: column;
+  justify-content: center;
+
+  padding: 5rem 0;
+}
+
+footer {
+  width: 100%;
+  height: 3rem;
+  padding-top: 1rem;
+
+  text-align: center;
+
+  border-top: 1px solid #eaeaea;
+}
+
+.docs-header h1 {
+  margin-top: 1rem;
+}
+
+.link-parent {
+  text-transform: capitalize;
+}
+
+/* docs-table - copied from docs */
+.scroll-table {
+  overflow-x: auto;
+
+  width: 100%;
+}
+
+.docs-table {
+  overflow: hidden;
+
+  border: 1px solid var(--brand-smoke-plus-20);
+  border-radius: 3px 3px 0 0;
+}
+
+.docs-table > thead > tr > td,
+.docs-table > thead > tr > th {
+  padding: calc(var(--spacer) * 2) calc(var(--spacer) * 3) !important;
+}
+
+.docs-table > tbody > tr > td,
+.docs-table > tbody > tr > th {
+  padding: calc(var(--spacer) * 3) calc(var(--spacer) * 3) !important;
+}
+
+.docs-table .table-condensed > tbody > tr > td,
+.docs-table .table-condensed > tbody > tr > th {
+  padding: calc(var(--spacer) * 2) calc(var(--spacer) * 3) !important;
+}
+
+.docs-table > thead {
+  color: white;
+  background-color: var(--brand-navy);
+}
+
+.docs-table > tbody > tr > th {
+  padding-left: 5px;
+
+  color: var(--brand-navy);
+}
+
+.docs-table ul {
+  margin-bottom: var(--spacer);
+  padding: 0;
+}
+
+.docs-table li {
+  list-style-type: none;
+}
+
+.docs-is-visible {
+  color: #468847;
+  background-color: #dff0d8 !important;
+}

--- a/packages/css/pages/index.js
+++ b/packages/css/pages/index.js
@@ -1,0 +1,80 @@
+import Head from 'next/head';
+import Link from 'next/link';
+
+const getPages = () => {
+  const req = require.context('./styles/', true, /mdx$/);
+
+  const fileTree = {};
+
+  req.keys().forEach((filePath) => {
+    const pathParts = filePath.slice(2, filePath.length - 4).split('/');
+    const resolvedPath = `styles/${pathParts.join('/')}`;
+
+    const fileName = pathParts.pop();
+    let insertAt = fileTree;
+
+    pathParts.forEach((part) => {
+      if (!insertAt[part]) {
+        insertAt[part] = {};
+      }
+      insertAt = insertAt[part];
+    });
+    insertAt[fileName] = {
+      name: req(filePath).meta.name,
+      path: resolvedPath,
+    };
+  });
+
+  return fileTree;
+};
+
+const getPageLinks = (pages) => (
+  <ul>
+    {Object.keys(pages).map((page) => {
+      return (
+        <li key={page}>
+          {pages[page].path ? (
+            <Link href={{ pathname: pages[page].path, query: { name: pages[page].name } }}>
+              {/* eslint-disable-next-line */}
+              <a>{pages[page].name}</a>
+            </Link>
+          ) : (
+            parentLink(pages, page)
+          )}
+        </li>
+      );
+    })}
+  </ul>
+);
+
+const parentLink = (pages, page) => (
+  <>
+    <span className="link-parent">{page}</span>
+    {getPageLinks(pages[page])}
+  </>
+);
+
+export default function Home() {
+  return (
+    <div className="home">
+      <Head>
+        <title>Neptune CSS Playground</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
+      <main>
+        <h1 className="title">Neptune CSS Playground</h1>
+        {getPageLinks(getPages())}
+      </main>
+
+      <footer>
+        Made with&nbsp;
+        <span role="img" aria-label="love">
+          ❤️
+        </span>
+        &nbsp;by the&nbsp;<a href="https://transferwise.github.io/neptune-web/">Neptune</a>
+        &nbsp;team
+      </footer>
+    </div>
+  );
+}

--- a/packages/css/pages/index.js
+++ b/packages/css/pages/index.js
@@ -72,8 +72,6 @@ export default function Home() {
         <span role="img" aria-label="love">
           ❤️
         </span>
-        &nbsp;by the&nbsp;<a href="https://transferwise.github.io/neptune-web/">Neptune</a>
-        &nbsp;team
       </footer>
     </div>
   );

--- a/packages/css/src/img/bg-dark.svg
+++ b/packages/css/src/img/bg-dark.svg
@@ -1,0 +1,31 @@
+<svg width="1440" height="750" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <path id="a" d="M0 0h1440v750H0z"/>
+    <linearGradient x1="44.248%" y1="75.156%" x2="61.919%" y2="-.312%" id="b">
+      <stop stop-color="#5643E5" offset="0%"/>
+      <stop stop-color="#5643E5" stop-opacity=".1" offset="100%"/>
+    </linearGradient>
+    <linearGradient x1="44.251%" y1="75.156%" x2="61.912%" y2="-.312%" id="d">
+      <stop stop-color="#5643E5" offset="0%"/>
+      <stop stop-color="#5643E5" stop-opacity=".1" offset="100%"/>
+    </linearGradient>
+    <linearGradient x1="56.26%" y1="23.838%" x2="38.365%" y2="100.312%" id="e">
+      <stop stop-color="#365080" stop-opacity=".1" offset="0%"/>
+      <stop stop-color="#365080" offset="100%"/>
+    </linearGradient>
+    <linearGradient x1="56.26%" y1="23.838%" x2="38.365%" y2="100.312%" id="f">
+      <stop stop-color="#365080" stop-opacity=".1" offset="0%"/>
+      <stop stop-color="#5643E5" offset="100%"/>
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <mask id="c" fill="#fff">
+      <use xlink:href="#a"/>
+    </mask>
+    <use fill="#37517E" xlink:href="#a"/>
+    <path fill-opacity=".9" fill="url(#b)" fill-rule="nonzero" opacity=".652" mask="url(#c)" d="M874 1639.892L1542.214 63h306.662l-668.213 1576.892z"/>
+    <path fill-opacity=".5" fill="url(#d)" fill-rule="nonzero" opacity=".552" mask="url(#c)" d="M-980 4408.892L725.96 382h782.916l-1705.96 4026.892z"/>
+    <path fill="url(#e)" fill-rule="nonzero" opacity=".04" mask="url(#c)" d="M1554.978 74H1130l926.022-2186H2481z"/>
+    <path fill="url(#f)" fill-rule="nonzero" mask="url(#c)" d="M-571 1261L355.022-925H780l-926.022 2186z"/>
+  </g>
+</svg>

--- a/packages/css/src/img/bg-light.svg
+++ b/packages/css/src/img/bg-light.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 682">
+  <g transform="translate(-97 -5)">
+    <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="1579.967" y1="-1.607" x2="1579.364" y2="-.725" gradientTransform="matrix(285.8258 9.9814 -16.0191 458.7204 -451243.625 -15127.07)">
+      <stop offset="0" stop-color="#e2e6e8" stop-opacity=".1"/>
+      <stop offset="1" stop-color="#e2e6e8"/>
+    </linearGradient>
+    <path d="M356.4-149.1l91.2 3.2L237.1 306l-91.2-3.2 210.5-451.9z" fill="url(#a)"/>
+    <linearGradient id="b" gradientUnits="userSpaceOnUse" x1="1580.086" y1="-.836" x2="1579.204" y2="-1.439" gradientTransform="matrix(285.8258 9.9814 -16.0191 458.7204 -451391.875 -15008.172)">
+      <stop offset="0" stop-color="#e2e6e8" stop-opacity=".1"/>
+      <stop offset="1" stop-color="#e2e6e8"/>
+    </linearGradient>
+    <path d="M189.8 10.1l91.2 3.2L70.4 465.2l-91.2-3.2L189.8 10.1z" fill="url(#b)"/>
+  </g>
+  <g transform="translate(1113 99)">
+    <linearGradient id="c" gradientUnits="userSpaceOnUse" x1="-840.145" y1="-1.258" x2="-840.748" y2="-.375" gradientTransform="matrix(285.8258 9.9814 -16.0191 458.7204 240450.375 9070.022)">
+      <stop offset="0" stop-color="#e2e6e8" stop-opacity=".1"/>
+      <stop offset="1" stop-color="#e2e6e8"/>
+    </linearGradient>
+    <path d="M314.5 51.8l91.2 3.2-210.5 451.9-91.2-3.2L314.5 51.8z" fill="url(#c)"/>
+    <linearGradient id="d" gradientUnits="userSpaceOnUse" x1="-839.966" y1="-.576" x2="-840.848" y2="-1.179" gradientTransform="matrix(285.8258 9.9814 -16.0191 458.7204 240302.125 9188.92)">
+      <stop offset="0" stop-color="#e2e6e8" stop-opacity=".1"/>
+      <stop offset="1" stop-color="#e2e6e8"/>
+    </linearGradient>
+    <path d="M166.3 170.7l91.2 3.2L46.9 625.8l-91.2-3.2 210.6-451.9z" fill="url(#d)"/>
+  </g>
+</svg>

--- a/packages/css/src/less/background.less
+++ b/packages/css/src/less/background.less
@@ -1,0 +1,16 @@
+.bg {
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-size: 100%;
+  background-position: bottom;
+
+  &--dark {
+    background-color: var(--color-primary);
+    background-image: url(../img/bg-dark.svg);
+  }
+
+  &--light {
+    background-color: var(--color-background-neutral);
+    background-image: url(../img/bg-light.svg);
+  }
+}

--- a/packages/css/src/less/blocks.less
+++ b/packages/css/src/less/blocks.less
@@ -3,7 +3,7 @@
 .block {
   display: block;
   background: var(--color-background-elevated);
-  box-shadow: 0 16px 30px 0 rgba(@brand-blue--rbg, 0.2);
+  box-shadow: 0 0 30px 0 rgba(@brand-blue--rbg, 0.2);
   padding: var(--size-16);
   border-radius: 3px;
 
@@ -26,7 +26,7 @@
 
   &:hover {
     text-decoration: none;
-    box-shadow: 0 16px 30px 0 rgba(@brand-blue--rbg, 0.3);
+    box-shadow: 0 0 30px 0 rgba(@brand-blue--rbg, 0.3);
 
     .block-caretLink .glyphicon {
       transform: translateX(2px);

--- a/packages/css/src/less/blocks.less
+++ b/packages/css/src/less/blocks.less
@@ -1,0 +1,42 @@
+@brand-blue--rbg: 34, 48, 73;
+
+.block {
+  display: block;
+  background: var(--color-background-elevated);
+  box-shadow: 0 16px 30px 0 rgba(@brand-blue--rbg, 0.2);
+  padding: var(--size-16);
+  border-radius: 3px;
+
+  @media (--screen-sm) {
+    padding: var(--size-24) var(--size-16);
+  }
+
+  @media (--screen-md) {
+    padding: var(--size-32) var(--size-16);
+  }
+
+  @media (--screen-lg) {
+    padding: var(--size-48) var(--size-16);
+  }
+}
+
+.block--withLink {
+  text-decoration: none;
+  transition: all 0.15s;
+
+  &:hover {
+    text-decoration: none;
+    box-shadow: 0 16px 30px 0 rgba(@brand-blue--rbg, 0.3);
+
+    .block-caretLink .glyphicon {
+      transform: translateX(2px);
+    }
+  }
+}
+
+.block-caretLink .glyphicon {
+  position: relative;
+  top: -1px;
+  font-size: 8px;
+  transition: all 0.15s;
+}

--- a/packages/css/src/less/circle-backgrounds.less
+++ b/packages/css/src/less/circle-backgrounds.less
@@ -1,0 +1,38 @@
+// Deprecated CSS component: We keep importing it from Bootstrap because in theory it is not meant to update. If so, replicate the code here with modern syntax.
+
+// variables
+@import (reference) 'bootstrap/less/variables.less';
+
+// mixins
+@import (reference) 'bootstrap/less/mixins/circle-background.less';
+@import 'bootstrap/less/circle-background.less';
+
+.circle-bg-margin {
+  margin-top: 60%;
+  margin-bottom: 60%;
+}
+
+.circle-bg-xs-margin {
+  margin-top: 12.5%;
+  margin-bottom: 12.5%;
+}
+
+.circle-bg-sm-margin {
+  margin-top: 25%;
+  margin-bottom: 25%;
+}
+
+.circle-bg-margin {
+  margin-top: 100%;
+  margin-bottom: 100%;
+}
+
+.circle-bg-lg-margin {
+  margin-top: 150%;
+  margin-bottom: 150%;
+}
+
+.circle-bg-xl-margin {
+  margin-top: 200%;
+  margin-bottom: 200%;
+}

--- a/packages/css/src/less/grid-layout.less
+++ b/packages/css/src/less/grid-layout.less
@@ -1,0 +1,216 @@
+.container {
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--size-16);
+  padding-left: var(--size-16);
+
+  @media (--screen-sm) {
+    padding-right: var(--size-24);
+    padding-left: var(--size-24);
+  }
+
+  @media (--screen-lg) {
+    padding-right: var(--size-32);
+    padding-left: var(--size-32);
+  }
+
+  @media (--screen-xl) {
+    max-width: 1164px;
+  }
+}
+
+.container-10 {
+  width: 83.33333333%;
+  margin: auto;
+
+  &--md {
+    @media (--screen-md) {
+      display: grid;
+      grid-template-columns: var(--gap) 1fr var(--gap);
+
+      > * {
+        grid-column: 2;
+      }
+    }
+  }
+}
+
+.container-8 {
+  width: 66.66666667%;
+  margin: auto;
+
+  &--md {
+    @media (--screen-md) {
+      width: 66.66666667%;
+      margin: auto;
+    }
+  }
+}
+
+[class^='grid-'],
+[class*=' grid-'] {
+  display: grid;
+
+  &::before {
+    content: none; /* Permits to use with container */
+  }
+}
+
+.grid-4 {
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: 25% 25% 25% 25%;
+  grid-template-columns: column 100px 100px 1fr;
+}
+
+.grid-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.grid-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+[class^='grid-'],
+[class*=' grid-'] {
+  @media all and (--screen-sm) {
+    &.grid-4--sm {
+      grid-template-columns: repeat(4, 1fr);
+    }
+
+    &.grid-3--sm {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    &.grid-2--sm {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+}
+
+[class^='grid-'],
+[class*=' grid-'] {
+  @media all and (--screen-md) {
+    &.grid-4--md {
+      grid-template-columns: repeat(4, 1fr);
+    }
+
+    &.grid-3--md {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    &.grid-2--md {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+}
+
+[class^='grid-'],
+[class*=' grid-'] {
+  @media all and (--screen-lg) {
+    &.grid-4--lg {
+      grid-template-columns: repeat(4, 1fr);
+    }
+
+    &.grid-3--lg {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    &.grid-2--lg {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+}
+
+/* Gaps */
+
+:root {
+  --gap: calc(100% / 12);
+}
+
+.gap {
+  grid-gap: var(--size-16);
+
+  @media (--screen-md) {
+    grid-gap: var(--size-24);
+  }
+
+  &--32 {
+    grid-gap: var(--size-32);
+  }
+
+  &--column {
+    grid-column-gap: calc(100% / 12);
+  }
+}
+
+.no-gap {
+  grid-gap: 0;
+}
+
+.grid-row-gap--6 {
+  grid-row-gap: calc(var(--size-8) * 6);
+}
+
+/* Patterns */
+
+.grid-sidebar {
+  @media (--screen-md) {
+    grid-template-columns: 264px 1fr;
+  }
+}
+
+/* Alignments */
+
+.justify-self-center {
+  > * {
+    justify-self: center;
+  }
+}
+
+.align-items-start {
+  align-items: flex-start;
+}
+
+.align-items-center {
+  align-items: center;
+}
+
+.align-items-end {
+  align-items: flex-end;
+}
+
+.align-self-center {
+  > * {
+    align-self: center;
+  }
+}
+
+/* Reverse */
+
+.reverse {
+  grid-auto-flow: dense;
+
+  > *:first-child {
+    grid-column-end: -1;
+  }
+
+  &.grid-3,
+  &.grid-4 {
+    > *:nth-child(2) {
+      grid-column-end: -2;
+    }
+  }
+
+  &.grid-4 {
+    > *:nth-child(3) {
+      grid-column-end: -3;
+    }
+  }
+}
+
+/* Ordering */
+.order-1--mobile {
+  @media (--screen-sm-max) {
+    order: -1;
+  }
+}

--- a/packages/css/src/less/jumbotron.less
+++ b/packages/css/src/less/jumbotron.less
@@ -1,0 +1,5 @@
+// Deprecated CSS component: We keep importing it from Bootstrap because in theory it is not meant to update. If so, replicate the code here with modern syntax.
+
+// variables
+@import (reference) 'bootstrap/less/variables.less';
+@import 'bootstrap/less/jumbotron.less';

--- a/packages/css/src/less/pagination.less
+++ b/packages/css/src/less/pagination.less
@@ -1,0 +1,4 @@
+// Deprecated CSS component: We keep importing it from Bootstrap because in theory it is not meant to update. If so, replicate the code here with modern syntax.
+
+@import (reference) 'bootstrap/less/variables.less';
+@import 'bootstrap/less/pagination.less';

--- a/packages/docs/components/Layout.js
+++ b/packages/docs/components/Layout.js
@@ -29,7 +29,7 @@ const Layout = ({ children, router: { pathname } }) => {
         </a>
       </Link>
       <ul className="Nav Nav--dark">
-        <li className="Nav__Group">Neptune</li>
+        <li className="Nav__Group">Neptune Marketing</li>
         {sections.map((section) => (
           <li key={section.title}>
             <Link href={getFirstPageInSection(section).path}>
@@ -51,6 +51,7 @@ const Layout = ({ children, router: { pathname } }) => {
     <div className="Content" role="main">
       {page && <h1 className="colored-dot">{page.component.meta.name}</h1>}
       {page && page.component.meta.isBeta && <span className="badge">beta</span>}
+      {page && page.component.meta.size && <p>{page.component.meta.size}</p>}
       {children}
       <a className="btn btn-default m-t-4" href={editPath}>
         Edit these docs on Github

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -38,7 +38,6 @@
     "@mdx-js/loader": "^1.5.8",
     "@next/mdx": "^9.0.5",
     "@transferwise/marketing-components": "^2.2.1",
-    "@transferwise/neptune-css": "^2.1.2",
     "@zeit/next-css": "^1.0.1",
     "bootstrap": "github:transferwise/bootstrap#semver:^5.20.0",
     "glob": "^7.1.6",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -37,6 +37,7 @@
     "@mapbox/rehype-prism": "^0.4.0",
     "@mdx-js/loader": "^1.5.8",
     "@next/mdx": "^9.0.5",
+    "@transferwise/neptune-css": "^4.0.5",
     "@transferwise/marketing-components": "^2.2.1",
     "@zeit/next-css": "^1.0.1",
     "bootstrap": "github:transferwise/bootstrap#semver:^5.20.0",

--- a/packages/docs/pages/css/About.mdx
+++ b/packages/docs/pages/css/About.mdx
@@ -1,6 +1,6 @@
 Marketing CSS Components are meant to use in combination with <a href="https://transferwise.github.io/neptune-web/styles">Neptune-css</a> Learn <a href="https://transferwise.github.io/neptune-web/about/Styles"> here the basics</a>.
 
-These componets are particularly used in public marketing pages and some of them have been deprecated from general `neptune-css` bundle, which has a product orientation.
+These components are particularly used in public marketing pages and some of them have been deprecated from general `�neptune-css` bundle, which has a product orientation.
 
 Other components, as the `Grid Layout` system, it's brand new for marketing purposes, a lightweight simple way to create layouts. This system doesn't support IE11 so take that into account when you have to take decisions.
 

--- a/packages/docs/pages/css/About.mdx
+++ b/packages/docs/pages/css/About.mdx
@@ -1,0 +1,16 @@
+Marketing CSS Components are meant to use in combination with <a href="https://transferwise.github.io/neptune-web/styles">Neptune-css</a> Learn <a href="https://transferwise.github.io/neptune-web/about/Styles"> here the basics</a>.
+
+These componets are particularly used in public marketing pages and some of them have been deprecated from general `neptune-css` bundle, which has a product orientation.
+
+Other components, as the `Grid Layout` system, it's brand new for marketing purposes, a lightweight simple way to create layouts. This system doesn't support IE11 so take that into account when you have to take decisions.
+
+## Usage
+
+The Marketing CSS components are available in `@transferwise/marketing-css` NPM package, and you can import the component you need individually.
+
+    import '@transferwise/marketing-css/dist/css/grid-layout.css';
+
+
+export const meta = {
+  name: 'About',
+};

--- a/packages/docs/pages/css/Background.mdx
+++ b/packages/docs/pages/css/Background.mdx
@@ -1,5 +1,4 @@
 import '../../../css/dist/css/background.css';
-import './docs.css';
 
 ## Dark
 

--- a/packages/docs/pages/css/Background.mdx
+++ b/packages/docs/pages/css/Background.mdx
@@ -1,0 +1,19 @@
+import '../../../css/dist/css/background.css';
+import './docs.css';
+
+## Dark
+
+    <div class="bg bg--dark"></div>
+
+<div className="bg bg--dark docs-bg"></div>
+
+## Light
+
+    <div class="bg bg--light"></div>
+
+<div className="bg bg--light docs-bg"></div>
+
+export const meta = {
+  name: 'Background',
+  size: '<1KB',
+};

--- a/packages/docs/pages/css/Blocks.mdx
+++ b/packages/docs/pages/css/Blocks.mdx
@@ -1,0 +1,58 @@
+import '../../../css/dist/css/blocks.css';
+
+## Default
+
+    <div class="block">
+      ...
+    </div>
+
+<div className="block m-b-4">
+  <h4>I am a block</h4>
+</div>
+
+## with link
+
+    <a class="block block--withLink" href="#">
+    ...
+    </a>
+
+<a className="block block--withLink m-b-4" href="#">
+  <h4>I am a block</h4>
+  <span className="block-caretLink">
+    <span>Learn more</span> <span className="glyphicon glyphicon-chevron-right"></span>
+  </span>
+</a>
+
+## Example with grid layout columns
+
+    <div class="grid-3 gap--column">
+      <a class="block block--withLink" href="#">...</a>
+      <a class="block block--withLink" href="#">...</a>
+      <a class="block block--withLink" href="#">...</a>
+    </div>
+
+<div className="grid-3 gap--column">
+  <a className="block block--withLink" href="#">
+    <h4>I am a block</h4>
+    <span className="block-caretLink">
+      <span>Learn more</span> <span className="glyphicon glyphicon-chevron-right"></span>
+    </span>
+  </a>
+  <a className="block block--withLink" href="#">
+    <h4>I am a block</h4>
+    <span className="block-caretLink">
+      <span>Learn more</span> <span className="glyphicon glyphicon-chevron-right"></span>
+    </span>
+  </a>
+  <a className="block block--withLink" href="#">
+    <h4>I am a block</h4>
+    <span className="block-caretLink">
+      <span>Learn more</span> <span className="glyphicon glyphicon-chevron-right"></span>
+    </span>
+  </a>
+</div>
+
+export const meta = {
+  name: 'Blocks',
+  size: '<1KB',
+};

--- a/packages/docs/pages/css/CircleBackgrounds.mdx
+++ b/packages/docs/pages/css/CircleBackgrounds.mdx
@@ -475,7 +475,7 @@ We need several colour modifiers for our regular background colours:
     <div class="circle-bg circle-bg-navy">Dark navy blue</div>
 
 <div className="alert alert-info">
-  There are available utility clases to control the vertical margin of the circle background
+  There are utility classes available to control the vertical margin of the circle background
   element.
 </div>
 

--- a/packages/docs/pages/css/CircleBackgrounds.mdx
+++ b/packages/docs/pages/css/CircleBackgrounds.mdx
@@ -394,7 +394,7 @@ variant (2x width) and side positioning.
     <div class="circle-bg circle-bg-xl circle-bg-left">...</div>
 
 <h2 id="circle-bg-clip">Clipping boxes </h2>
-Sometime we want to clip the circle, we should do this with a clipping box at a higher level.
+Sometimes we want to clip the circle, we should do this with a clipping box at a higher level.
 
 <div className="row circle-bg-clip box-dashed">
   <div className="col-xs-6 m-t-5 m-b-5">Clip</div>

--- a/packages/docs/pages/css/CircleBackgrounds.mdx
+++ b/packages/docs/pages/css/CircleBackgrounds.mdx
@@ -1,0 +1,489 @@
+Backgrounds are applied to box elements. This could be a grid column, a page width block, or
+something custom.
+
+- [Default](#circle-bg-default)
+- [Sizes](#circle-bg-sizes)
+- [Positions (center)](#circle-bg-pos-c)
+- [Position (box edge)](#circle-bg-pos)
+- [Size and positions](#circle-bg-size-pos)
+- [Clipping boxes](#circle-bg-clip)
+- [Colours](#circle-bg-colour)
+
+The <strong>size is based on the width</strong> of the container. It is slightly larger than the
+container to make sure content has a background.
+
+<h2 id="circle-bg-default">Defaults</h2>
+
+By default it is <strong>centered both vertically and horizontally</strong> on the box and <strong> not clipped</strong> by the edge of the box.
+
+<div class="row">
+  <div class="col-xs-4 col-sm-offset-4">
+    <div class="circle-bg circle-bg-margin">
+      <h3>Default circle</h3>
+    </div>
+  </div>
+</div>
+
+    <div class="circle-bg">
+    ...
+    </div>
+
+<h2 id="circle-bg-sizes">Sizes</h2>
+Size modifiers do not move the centre of the circle, they just alter the size.
+
+Example logic:
+
+- xs: 0.25 \* width
+- sm: 0.5 \* wisdth
+- md: 1.2 \* width (default)
+- lg: 2 \* width
+- xl: 4 \* width
+
+<div class="row">
+  <div class="col-xs-4">
+    <div class="box-dashed circle-bg circle-bg-xs circle-bg-margin">
+      <h3>xs</h3>
+    </div>
+  </div>
+  <div class="col-xs-4">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-margin">
+      <h3>sm</h3>
+    </div>
+  </div>
+  <div class="col-xs-4">
+    <div class="box-dashed circle-bg circle-bg-md circle-bg-margin">
+      <h3>md</h3>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-4 col-xs-offset-4">
+    <div class="circle-bg circle-bg-lg circle-bg-lg-margin">
+      <h3>lg</h3>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-4 col-xs-offset-4">
+    <div class="circle-bg circle-bg-xl circle-bg-xl-margin">
+      <h3>xl</h3>
+    </div>
+  </div>
+</div>
+
+    <div class="circle-bg circle-bg-xs">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-sm">
+    ...
+    </div>
+    <div class="circle-bg">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-lg">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-xl">
+    ...
+    </div>
+
+<h2 id="circle-bg-pos-c">Positions (center)</h2>
+The centre of the circle is moved just outside the edge of the container box. We can use modifier classes
+to choose the edge.
+
+- Top
+- Right
+- Bottom
+- Left
+
+We can also use these in x/y combinations.
+
+<div class="row">
+  <div class="col-xs-5 col-xs-offset-1">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-top-c">
+      <h3>top</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
+        autem similique culpa, optio vero, reiciendis nesciunt, odio, laborum adipisci obcaecati
+        labore dolores quasi.
+      </p>
+    </div>
+  </div>
+  <div class="col-xs-5 col-xs-offset-1">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-right-c">
+      <h3>right</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
+        autem similique culpa, optio vero, reiciendis nesciunt, odio, laborum adipisci obcaecati
+        labore dolores quasi.
+      </p>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-5 col-xs-offset-1">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-bottom-c">
+      <h3>bottom</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
+        autem similique culpa, optio vero, reiciendis nesciunt, odio, laborum adipisci obcaecati
+        labore dolores quasi.
+      </p>
+    </div>
+  </div>
+  <div class="col-xs-5 col-xs-offset-1">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-left-c">
+      <h3>left</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
+        autem similique culpa, optio vero, reiciendis nesciunt, odio, laborum adipisci obcaecati
+        labore dolores quasi.
+      </p>
+    </div>
+  </div>
+</div>
+
+    <div class="circle-bg circle-bg-top-c">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-right-c">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-bottom-c">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-left-c">
+    ...
+    </div>
+
+<h2 className="m-t-4">Position (center) x/y combinations</h2>
+<div class="row">
+  <div class="col-xs-5 col-xs-offset-1 ">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-top-c circle-bg-left-c circle-bg-sm-margin">
+      <h3>top left</h3> Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consectetur
+      adipisicing elit. Minus,
+    </div>
+  </div>
+  <div class="col-xs-5 col-xs-offset-1 ">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-top-c circle-bg-right-c circle-bg-sm-margin ">
+      <h3>Top Right</h3> Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consectetur
+      adipisicing elit.
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-5 col-xs-offset-1 ">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom-c circle-bg-left-c circle-bg-sm-margin">
+      <h3>Bottom Left</h3> Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consectetur
+      adipisicing elit.
+    </div>
+  </div>
+  <div class="col-xs-5 col-xs-offset-1 ">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom-c circle-bg-right-c circle-bg-sm-margin">
+      <h3>Bottom Right</h3> Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consectetur
+      adipisicing elit.
+    </div>
+  </div>
+</div>
+
+    <div class="circle-bg circle-bg-top-c circle-bg-left-c">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-top-c circle-bg-right-c">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-bottom-c circle-bg-left-c">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-bottom-c circle-bg-top-c">
+    ...
+    </div>
+
+<h2 id="circle-bg-pos">Position (box edge)</h2>
+
+The <strong>edge of the circle</strong> is moved just outside of the edge of the container box.
+
+Modifiers:
+
+- Top
+- Right
+- Bottom
+- Left
+
+We can also use these in x/y combinations.
+
+<div class="row">
+  <div class="col-xs-4 col-xs-offset-1">
+    <div class="box-dashed circle-bg circle-bg-top circle-bg-margin">
+      <h3>Top</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus</p>
+    </div>
+  </div>
+  <div class="col-xs-4 col-xs-offset-3">
+    <div class="box-dashed circle-bg circle-bg-right circle-bg-margin">
+      <h3>Right</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus</p>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-4 col-xs-offset-1">
+    <div class="box-dashed circle-bg circle-bg-bottom circle-bg-margin">
+      <h3>Bottom</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus</p>
+    </div>
+  </div>
+  <div class="col-xs-4 col-xs-offset-3">
+    <div class="box-dashed circle-bg circle-bg-left circle-bg-margin">
+      <h3>Left</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
+        autem similique culpa, optio vero, reiciendis nesciunt, odio, laborum adipisci obcaecati
+        labore dolores quasi.
+      </p>
+    </div>
+  </div>
+</div>
+
+    <div class="circle-bg circle-bg-top">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-right">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-bottom">
+    ...
+    </div>
+    <div class="circle-bg circle-bg-left">
+    ...
+    </div>
+
+<h2>Position (box edge) x/y combinations</h2>
+
+<div class="row m-b-5">
+  <div class="col-xs-4 col-xs-offset-1">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-top circle-bg-left">
+      <h3>Top Left</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus Lorem ipsum dolor sit amet,
+        consectetur adipisicing elit. Incidunt voluptas, cupiditate et blanditiis hic, alias
+        consectetur
+      </p>
+    </div>
+  </div>
+  <div class="col-xs-4 col-xs-offset-3">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-top circle-bg-right">
+      <h3>Top Right</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus Lorem ipsum dolor sit amet,
+        consectetur adipisicing elit. Incidunt voluptas, cupiditate et blanditiis hic, alias
+        consectetur
+      </p>
+    </div>
+  </div>
+</div>
+<div class="row ">
+  <div class="col-xs-4 col-xs-offset-1">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom circle-bg-left">
+      <h3>Bottom Left</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus Lorem ipsum dolor sit amet,
+        consectetur adipisicing elit. Incidunt voluptas, cupiditate et blanditiis hic, alias
+        consectetur
+      </p>
+    </div>
+  </div>
+  <div class="col-xs-4 col-xs-offset-3">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom circle-bg-right">
+      <h3>Bottom Right</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus Lorem ipsum dolor sit amet,
+        consectetur adipisicing elit. Incidunt voluptas, cupiditate et blanditiis hic, alias
+        consectetur
+      </p>
+    </div>
+  </div>
+</div>
+
+      <div class="circle-bg circle-bg-top circle-bg-left">
+        ...
+      </div>
+      <div class="circle-bg circle-bg-top circle-bg-right">
+        ...
+      </div>
+      <div class="circle-bg circle-bg-bottom circle-bg-left">
+        ...
+      </div>
+      <div class="circle-bg circle-bg-bottom circle-bg-right">
+        ...
+      </div>
+
+<h2 id="circle-bg-size-pos">Size and positions</h2>
+We can use these together for different effects.
+
+<div class="row">
+  <div class="col-xs-4">
+    <div class="box-dashed circle-bg circle-bg-xs circle-bg-top circle-bg-right circle-bg-sm-margin">
+      <h3>xs top right</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi ad omnis esse
+        accusantium harum veniam, ex in numquam accusamus commodi suscipit corrupti modi illum est
+        quod.
+      </p>
+    </div>
+  </div>
+  <div class="col-xs-4">
+    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom circle-bg-right circle-bg-sm-margin">
+      <h3>sm bottom right</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
+        autem similique culpa, optio vero, reiciendis nesciunt, odio, laborum adipisci obcaecati
+        labore dolores quasi.
+      </p>
+    </div>
+  </div>
+  <div class="col-xs-4">
+    <div class="box-dashed circle-bg circle-bg-bottom circle-bg-left circle-bg-sm-margin">
+      <h3>md bottom left</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
+        autem similique culpa, optio vero, reiciendis nesciunt, odio, laborum adipisci obcaecati
+        labore dolores quasi.
+      </p>
+    </div>
+  </div>
+</div>
+
+    <div class="circle-bg circle-bg-xs circle-bg-top circle-bg-right">...</div>
+    <div class="circle-bg circle-bg-sm circle-bg-bottom circle-bg-right">...</div>
+    <div class="circle-bg circle-bg-bottom circle-bg-left">...</div>
+
+If we want to mostly cover the background of the box, but with an offset style, we could use the lg
+variant (2x width) and side positioning.
+
+<div class="row">
+  <div class="col-xs-4 col-xs-offset-4">
+    <div class="box-dashed circle-bg circle-bg-lg circle-bg-bottom circle-bg-left circle-bg-margin">
+      <h3>lg bottom left</h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente quisquam velit
+        perferendis sed. Et consectetur repudiandae dolore quibusdam unde ea, assumenda id non
+        consequuntur, minima ducimus. Eos iure atque voluptatem culpa sunt fugiat modi doloribus
+        vitae aliquid illo reiciendis et
+      </p>
+    </div>
+  </div>
+</div>
+
+    <div class="circle-bg circle-bg-lg circle-bg-bottom circle-bg-left">
+      ...
+    </div>
+
+<div class="row">
+  <div class="col-xs-4 col-xs-offset-4">
+    <div class="box-dashed circle-bg circle-bg-xl circle-bg-left circle-bg-xl-margin">
+      <h3>xl left</h3> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos consequatur
+      repellat nihil eaque doloribus assumenda accusantium laborum perferendis amet suscipit. Fugiat
+      fuga amet beatae id eaque sapiente, ipsa assumenda soluta, ex dolorum.
+    </div>
+  </div>
+</div>
+
+    <div class="circle-bg circle-bg-xl circle-bg-left">...</div>
+
+<h2 id="circle-bg-clip">Clipping boxes </h2>
+Sometime we want to clip the circle, we should do this with a clipping box at a higher level.
+
+<div class="row circle-bg-clip box-dashed">
+  <div class="col-xs-6 m-t-5 m-b-5">Clip</div>
+  <div class="col-xs-6 m-t-5 m-b-5">
+    <div class="box-dashed circle-bg circle-bg-lg circle-bg-left">lg left</div>
+  </div>
+</div>
+
+    <div class="circle-bg-clip">
+      <div class="col-xs-6">
+        Clip
+      </div>
+      <div class="col-xs-6">
+        <div class="circle-bg circle-bg-lg circle-bg-left">
+          lg left
+        </div>
+      </div>
+    </div>
+
+<h2 id="circle-bg-colour">Colours</h2>
+We need several colour modifiers for our regular background colours:
+
+- Light grey (for use on white)
+- Light blue (for use on white)
+- Dark navy blue (for use on light navy blue)
+- Light navy blue (for use on white)
+
+<div class="row">
+  <div class="col-xs-4 col-xs-offset-1">
+    <div class="row circle-bg-clip box-dashed">
+      <div class="col-xs-6 m-t-5 m-b-5">Some text</div>
+      <div class="col-xs-6 m-t-5 m-b-5">
+        <div class="box-dashed circle-bg circle-bg-lg circle-bg-left">Default color</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-xs-4 col-xs-offset-2">
+    <div class="row circle-bg-clip box-dashed">
+      <div class="col-xs-6 m-t-5 m-b-5">Some text</div>
+      <div class="col-xs-6 m-t-5 m-b-5">
+        <div class="circle-bg circle-bg-light-blue circle-bg-lg circle-bg-left">Light blue</div>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="row m-t-5">
+  <div class="col-xs-4 col-xs-offset-1">
+    <div class="row circle-bg-clip box-dashed">
+      <div class="col-xs-6 m-t-5 m-b-5">Some text</div>
+      <div class="col-xs-6 m-t-5 m-b-5">
+        <div class="circle-bg circle-bg-blue circle-bg-lg circle-bg-left">Navy blue</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-xs-4 col-xs-offset-2">
+    <div class="row circle-bg-clip box-dashed">
+      <div class="col-xs-6 m-t-5 m-b-5">Some text</div>
+      <div class="col-xs-6 m-t-5 m-b-5">
+        <div class="circle-bg circle-bg-navy circle-bg-lg circle-bg-left">Dark navy blue</div>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="row m-t-5">
+  <div class="col-xs-4 col-xs-offset-1">
+    <div class="row circle-bg-clip box-dashed bg-primary low-z-index">
+      <div class="col-xs-6 m-t-5 m-b-5">Navy blue</div>
+      <div class="col-xs-6 m-t-5 m-b-5">
+        <div class="circle-bg circle-bg-navy circle-bg-lg circle-bg-left">Dark navy blue</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+    <div class="circle-bg">Default color</div>
+    <div class="circle-bg circle-bg-light-blue">Light blue</div>
+    <div class="circle-bg circle-bg-blue">Navy blue</div>
+    <div class="circle-bg circle-bg-navy">Dark navy blue</div>
+
+<div class="alert alert-info">
+  There are available utility clases to control the vertical margin of the circle background
+  element.
+</div>
+
+    .circle-bg-xs-margin
+    .circle-bg-sm-margin
+    .circle-bg-margin
+    .circle-bg-lg-margin
+    .circle-bg-xl-margin
+
+export const meta = {
+  name: 'Circle Backgrounds',
+  size: '1KB',
+};

--- a/packages/docs/pages/css/CircleBackgrounds.mdx
+++ b/packages/docs/pages/css/CircleBackgrounds.mdx
@@ -1,3 +1,5 @@
+import '../../../css/dist/css/circle-backgrounds.css';
+
 Backgrounds are applied to box elements. This could be a grid column, a page width block, or
 something custom.
 
@@ -16,9 +18,9 @@ container to make sure content has a background.
 
 By default it is <strong>centered both vertically and horizontally</strong> on the box and <strong> not clipped</strong> by the edge of the box.
 
-<div class="row">
-  <div class="col-xs-4 col-sm-offset-4">
-    <div class="circle-bg circle-bg-margin">
+<div className="row">
+  <div className="col-xs-4 col-sm-offset-4">
+    <div className="circle-bg circle-bg-margin">
       <h3>Default circle</h3>
     </div>
   </div>
@@ -39,33 +41,33 @@ Example logic:
 - lg: 2 \* width
 - xl: 4 \* width
 
-<div class="row">
-  <div class="col-xs-4">
-    <div class="box-dashed circle-bg circle-bg-xs circle-bg-margin">
+<div className="row">
+  <div className="col-xs-4">
+    <div className="docs-box-dashed circle-bg circle-bg-xs circle-bg-margin">
       <h3>xs</h3>
     </div>
   </div>
-  <div class="col-xs-4">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-margin">
+  <div className="col-xs-4">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-margin">
       <h3>sm</h3>
     </div>
   </div>
-  <div class="col-xs-4">
-    <div class="box-dashed circle-bg circle-bg-md circle-bg-margin">
+  <div className="col-xs-4">
+    <div className="docs-box-dashed circle-bg circle-bg-md circle-bg-margin">
       <h3>md</h3>
     </div>
   </div>
 </div>
-<div class="row">
-  <div class="col-xs-4 col-xs-offset-4">
-    <div class="circle-bg circle-bg-lg circle-bg-lg-margin">
+<div className="row">
+  <div className="col-xs-4 col-xs-offset-4">
+    <div className="circle-bg circle-bg-lg circle-bg-lg-margin">
       <h3>lg</h3>
     </div>
   </div>
 </div>
-<div class="row">
-  <div class="col-xs-4 col-xs-offset-4">
-    <div class="circle-bg circle-bg-xl circle-bg-xl-margin">
+<div className="row">
+  <div className="col-xs-4 col-xs-offset-4">
+    <div className="circle-bg circle-bg-xl circle-bg-xl-margin">
       <h3>xl</h3>
     </div>
   </div>
@@ -98,9 +100,9 @@ to choose the edge.
 
 We can also use these in x/y combinations.
 
-<div class="row">
-  <div class="col-xs-5 col-xs-offset-1">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-top-c">
+<div className="row">
+  <div className="col-xs-5 col-xs-offset-1">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-top-c">
       <h3>top</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
@@ -109,8 +111,8 @@ We can also use these in x/y combinations.
       </p>
     </div>
   </div>
-  <div class="col-xs-5 col-xs-offset-1">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-right-c">
+  <div className="col-xs-5 col-xs-offset-1">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-right-c">
       <h3>right</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
@@ -120,9 +122,9 @@ We can also use these in x/y combinations.
     </div>
   </div>
 </div>
-<div class="row">
-  <div class="col-xs-5 col-xs-offset-1">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-bottom-c">
+<div className="row">
+  <div className="col-xs-5 col-xs-offset-1">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-bottom-c">
       <h3>bottom</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
@@ -131,8 +133,8 @@ We can also use these in x/y combinations.
       </p>
     </div>
   </div>
-  <div class="col-xs-5 col-xs-offset-1">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-left-c">
+  <div className="col-xs-5 col-xs-offset-1">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-sm-margin circle-bg-left-c">
       <h3>left</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
@@ -157,29 +159,29 @@ We can also use these in x/y combinations.
     </div>
 
 <h2 className="m-t-4">Position (center) x/y combinations</h2>
-<div class="row">
-  <div class="col-xs-5 col-xs-offset-1 ">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-top-c circle-bg-left-c circle-bg-sm-margin">
+<div className="row">
+  <div className="col-xs-5 col-xs-offset-1 ">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-top-c circle-bg-left-c circle-bg-sm-margin">
       <h3>top left</h3> Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consectetur
       adipisicing elit. Minus,
     </div>
   </div>
-  <div class="col-xs-5 col-xs-offset-1 ">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-top-c circle-bg-right-c circle-bg-sm-margin ">
+  <div className="col-xs-5 col-xs-offset-1 ">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-top-c circle-bg-right-c circle-bg-sm-margin ">
       <h3>Top Right</h3> Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consectetur
       adipisicing elit.
     </div>
   </div>
 </div>
-<div class="row">
-  <div class="col-xs-5 col-xs-offset-1 ">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom-c circle-bg-left-c circle-bg-sm-margin">
+<div className="row">
+  <div className="col-xs-5 col-xs-offset-1 ">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-bottom-c circle-bg-left-c circle-bg-sm-margin">
       <h3>Bottom Left</h3> Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consectetur
       adipisicing elit.
     </div>
   </div>
-  <div class="col-xs-5 col-xs-offset-1 ">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom-c circle-bg-right-c circle-bg-sm-margin">
+  <div className="col-xs-5 col-xs-offset-1 ">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-bottom-c circle-bg-right-c circle-bg-sm-margin">
       <h3>Bottom Right</h3> Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consectetur
       adipisicing elit.
     </div>
@@ -212,29 +214,29 @@ Modifiers:
 
 We can also use these in x/y combinations.
 
-<div class="row">
-  <div class="col-xs-4 col-xs-offset-1">
-    <div class="box-dashed circle-bg circle-bg-top circle-bg-margin">
+<div className="row">
+  <div className="col-xs-4 col-xs-offset-1">
+    <div className="docs-box-dashed circle-bg circle-bg-top circle-bg-margin">
       <h3>Top</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus</p>
     </div>
   </div>
-  <div class="col-xs-4 col-xs-offset-3">
-    <div class="box-dashed circle-bg circle-bg-right circle-bg-margin">
+  <div className="col-xs-4 col-xs-offset-3">
+    <div className="docs-box-dashed circle-bg circle-bg-right circle-bg-margin">
       <h3>Right</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus</p>
     </div>
   </div>
 </div>
-<div class="row">
-  <div class="col-xs-4 col-xs-offset-1">
-    <div class="box-dashed circle-bg circle-bg-bottom circle-bg-margin">
+<div className="row">
+  <div className="col-xs-4 col-xs-offset-1">
+    <div className="docs-box-dashed circle-bg circle-bg-bottom circle-bg-margin">
       <h3>Bottom</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus</p>
     </div>
   </div>
-  <div class="col-xs-4 col-xs-offset-3">
-    <div class="box-dashed circle-bg circle-bg-left circle-bg-margin">
+  <div className="col-xs-4 col-xs-offset-3">
+    <div className="docs-box-dashed circle-bg circle-bg-left circle-bg-margin">
       <h3>Left</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
@@ -260,9 +262,9 @@ We can also use these in x/y combinations.
 
 <h2>Position (box edge) x/y combinations</h2>
 
-<div class="row m-b-5">
-  <div class="col-xs-4 col-xs-offset-1">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-top circle-bg-left">
+<div className="row m-b-5">
+  <div className="col-xs-4 col-xs-offset-1">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-top circle-bg-left">
       <h3>Top Left</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus Lorem ipsum dolor sit amet,
@@ -271,8 +273,8 @@ We can also use these in x/y combinations.
       </p>
     </div>
   </div>
-  <div class="col-xs-4 col-xs-offset-3">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-top circle-bg-right">
+  <div className="col-xs-4 col-xs-offset-3">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-top circle-bg-right">
       <h3>Top Right</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus Lorem ipsum dolor sit amet,
@@ -282,9 +284,9 @@ We can also use these in x/y combinations.
     </div>
   </div>
 </div>
-<div class="row ">
-  <div class="col-xs-4 col-xs-offset-1">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom circle-bg-left">
+<div className="row ">
+  <div className="col-xs-4 col-xs-offset-1">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-bottom circle-bg-left">
       <h3>Bottom Left</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus Lorem ipsum dolor sit amet,
@@ -293,8 +295,8 @@ We can also use these in x/y combinations.
       </p>
     </div>
   </div>
-  <div class="col-xs-4 col-xs-offset-3">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom circle-bg-right">
+  <div className="col-xs-4 col-xs-offset-3">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-bottom circle-bg-right">
       <h3>Bottom Right</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus Lorem ipsum dolor sit amet,
@@ -321,9 +323,9 @@ We can also use these in x/y combinations.
 <h2 id="circle-bg-size-pos">Size and positions</h2>
 We can use these together for different effects.
 
-<div class="row">
-  <div class="col-xs-4">
-    <div class="box-dashed circle-bg circle-bg-xs circle-bg-top circle-bg-right circle-bg-sm-margin">
+<div className="row">
+  <div className="col-xs-4">
+    <div className="docs-box-dashed circle-bg circle-bg-xs circle-bg-top circle-bg-right circle-bg-sm-margin">
       <h3>xs top right</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi ad omnis esse
@@ -332,8 +334,8 @@ We can use these together for different effects.
       </p>
     </div>
   </div>
-  <div class="col-xs-4">
-    <div class="box-dashed circle-bg circle-bg-sm circle-bg-bottom circle-bg-right circle-bg-sm-margin">
+  <div className="col-xs-4">
+    <div className="docs-box-dashed circle-bg circle-bg-sm circle-bg-bottom circle-bg-right circle-bg-sm-margin">
       <h3>sm bottom right</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
@@ -342,8 +344,8 @@ We can use these together for different effects.
       </p>
     </div>
   </div>
-  <div class="col-xs-4">
-    <div class="box-dashed circle-bg circle-bg-bottom circle-bg-left circle-bg-sm-margin">
+  <div className="col-xs-4">
+    <div className="docs-box-dashed circle-bg circle-bg-bottom circle-bg-left circle-bg-sm-margin">
       <h3>md bottom left</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Natus minus animi a labore. Ipsam
@@ -361,9 +363,9 @@ We can use these together for different effects.
 If we want to mostly cover the background of the box, but with an offset style, we could use the lg
 variant (2x width) and side positioning.
 
-<div class="row">
-  <div class="col-xs-4 col-xs-offset-4">
-    <div class="box-dashed circle-bg circle-bg-lg circle-bg-bottom circle-bg-left circle-bg-margin">
+<div className="row">
+  <div className="col-xs-4 col-xs-offset-4">
+    <div className="docs-box-dashed circle-bg circle-bg-lg circle-bg-bottom circle-bg-left circle-bg-margin">
       <h3>lg bottom left</h3>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sapiente quisquam velit
@@ -379,9 +381,9 @@ variant (2x width) and side positioning.
       ...
     </div>
 
-<div class="row">
-  <div class="col-xs-4 col-xs-offset-4">
-    <div class="box-dashed circle-bg circle-bg-xl circle-bg-left circle-bg-xl-margin">
+<div className="row">
+  <div className="col-xs-4 col-xs-offset-4">
+    <div className="docs-box-dashed circle-bg circle-bg-xl circle-bg-left circle-bg-xl-margin">
       <h3>xl left</h3> Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos consequatur
       repellat nihil eaque doloribus assumenda accusantium laborum perferendis amet suscipit. Fugiat
       fuga amet beatae id eaque sapiente, ipsa assumenda soluta, ex dolorum.
@@ -394,10 +396,10 @@ variant (2x width) and side positioning.
 <h2 id="circle-bg-clip">Clipping boxes </h2>
 Sometime we want to clip the circle, we should do this with a clipping box at a higher level.
 
-<div class="row circle-bg-clip box-dashed">
-  <div class="col-xs-6 m-t-5 m-b-5">Clip</div>
-  <div class="col-xs-6 m-t-5 m-b-5">
-    <div class="box-dashed circle-bg circle-bg-lg circle-bg-left">lg left</div>
+<div className="row circle-bg-clip box-dashed">
+  <div className="col-xs-6 m-t-5 m-b-5">Clip</div>
+  <div className="col-xs-6 m-t-5 m-b-5">
+    <div className="docs-box-dashed circle-bg circle-bg-lg circle-bg-left">lg left</div>
   </div>
 </div>
 
@@ -420,48 +422,48 @@ We need several colour modifiers for our regular background colours:
 - Dark navy blue (for use on light navy blue)
 - Light navy blue (for use on white)
 
-<div class="row">
-  <div class="col-xs-4 col-xs-offset-1">
-    <div class="row circle-bg-clip box-dashed">
-      <div class="col-xs-6 m-t-5 m-b-5">Some text</div>
-      <div class="col-xs-6 m-t-5 m-b-5">
-        <div class="box-dashed circle-bg circle-bg-lg circle-bg-left">Default color</div>
+<div className="row">
+  <div className="col-xs-4 col-xs-offset-1">
+    <div className="row circle-bg-clip box-dashed">
+      <div className="col-xs-6 m-t-5 m-b-5">Some text</div>
+      <div className="col-xs-6 m-t-5 m-b-5">
+        <div className="docs-box-dashed circle-bg circle-bg-lg circle-bg-left">Default color</div>
       </div>
     </div>
   </div>
-  <div class="col-xs-4 col-xs-offset-2">
-    <div class="row circle-bg-clip box-dashed">
-      <div class="col-xs-6 m-t-5 m-b-5">Some text</div>
-      <div class="col-xs-6 m-t-5 m-b-5">
-        <div class="circle-bg circle-bg-light-blue circle-bg-lg circle-bg-left">Light blue</div>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="row m-t-5">
-  <div class="col-xs-4 col-xs-offset-1">
-    <div class="row circle-bg-clip box-dashed">
-      <div class="col-xs-6 m-t-5 m-b-5">Some text</div>
-      <div class="col-xs-6 m-t-5 m-b-5">
-        <div class="circle-bg circle-bg-blue circle-bg-lg circle-bg-left">Navy blue</div>
-      </div>
-    </div>
-  </div>
-  <div class="col-xs-4 col-xs-offset-2">
-    <div class="row circle-bg-clip box-dashed">
-      <div class="col-xs-6 m-t-5 m-b-5">Some text</div>
-      <div class="col-xs-6 m-t-5 m-b-5">
-        <div class="circle-bg circle-bg-navy circle-bg-lg circle-bg-left">Dark navy blue</div>
+  <div className="col-xs-4 col-xs-offset-2">
+    <div className="row circle-bg-clip box-dashed">
+      <div className="col-xs-6 m-t-5 m-b-5">Some text</div>
+      <div className="col-xs-6 m-t-5 m-b-5">
+        <div className="circle-bg circle-bg-light-blue circle-bg-lg circle-bg-left">Light blue</div>
       </div>
     </div>
   </div>
 </div>
-<div class="row m-t-5">
-  <div class="col-xs-4 col-xs-offset-1">
-    <div class="row circle-bg-clip box-dashed bg-primary low-z-index">
-      <div class="col-xs-6 m-t-5 m-b-5">Navy blue</div>
-      <div class="col-xs-6 m-t-5 m-b-5">
-        <div class="circle-bg circle-bg-navy circle-bg-lg circle-bg-left">Dark navy blue</div>
+<div className="row m-t-5">
+  <div className="col-xs-4 col-xs-offset-1">
+    <div className="row circle-bg-clip box-dashed">
+      <div className="col-xs-6 m-t-5 m-b-5">Some text</div>
+      <div className="col-xs-6 m-t-5 m-b-5">
+        <div className="circle-bg circle-bg-blue circle-bg-lg circle-bg-left">Navy blue</div>
+      </div>
+    </div>
+  </div>
+  <div className="col-xs-4 col-xs-offset-2">
+    <div className="row circle-bg-clip box-dashed">
+      <div className="col-xs-6 m-t-5 m-b-5">Some text</div>
+      <div className="col-xs-6 m-t-5 m-b-5">
+        <div className="circle-bg circle-bg-navy circle-bg-lg circle-bg-left">Dark navy blue</div>
+      </div>
+    </div>
+  </div>
+</div>
+<div className="row m-t-5">
+  <div className="col-xs-4 col-xs-offset-1">
+    <div className="row circle-bg-clip box-dashed bg-primary low-z-index">
+      <div className="col-xs-6 m-t-5 m-b-5">Navy blue</div>
+      <div className="col-xs-6 m-t-5 m-b-5">
+        <div className="circle-bg circle-bg-navy circle-bg-lg circle-bg-left">Dark navy blue</div>
       </div>
     </div>
   </div>
@@ -472,7 +474,7 @@ We need several colour modifiers for our regular background colours:
     <div class="circle-bg circle-bg-blue">Navy blue</div>
     <div class="circle-bg circle-bg-navy">Dark navy blue</div>
 
-<div class="alert alert-info">
+<div className="alert alert-info">
   There are available utility clases to control the vertical margin of the circle background
   element.
 </div>

--- a/packages/docs/pages/css/GridLayout.mdx
+++ b/packages/docs/pages/css/GridLayout.mdx
@@ -1,0 +1,490 @@
+import '../../../css/dist/css/grid-layout.css';
+
+<div className="container">
+  <p>
+    TW Grid layout system created for building modern web layouts easily.
+  </p>
+  <div className="grid-3 gap">
+    <ul className="m-t-4">
+      <li>
+        <a href="#general-usage">General usage</a>
+      </li>
+      <li>
+        <a href="#container">Container</a>
+      </li>
+      <li>
+        <a href="#responsive-columns">Responsive columns</a>
+      </li>
+      <li>
+        <a href="#nesting">Nesting grids</a>
+      </li>
+      <li>
+        <a href="#rows">Rows</a>
+      </li>
+      <li>
+        <a href="#gap">Gap</a>
+      </li>
+      <li>
+        <a href="#reverse">Reverse</a>
+      </li>
+      <li>
+        <a href="#order">Ordering</a>
+      </li>
+      <li>
+        <a href="#alignment">Alignment</a>
+      </li>
+      <li>
+        <a href="#common-patterns">Common patterns</a>
+      </li>
+    </ul>
+    <div>
+      <h3>Pros</h3>
+      <ul>
+        <li>Lightweight. 4KB vs 15KB (Bootstrap grid system)</li>
+        <li>Simple to use</li>
+        <li>Custom system to our needs. Flexible</li>
+        <li>Easy reverse and ordering</li>
+        <li>Less code. Simple DOM.</li>
+        <li>Use of standard and modern code</li>
+        <li>Can be used in combination with other layout systems (Flex, cols system). It's not exclusive.</li>
+      </ul>
+    </div>
+    <div>
+      <h3>Cons</h3>
+      <ul>
+        <li>Not supported in IE11</li>
+      </ul>
+    </div>
+  </div>
+  <p>
+  <p><span>Want to know more about grid layout? </span>
+  <a
+    href="https://css-tricks.com/snippets/css/complete-guide-grid/"
+    target="_blank"
+    rel="noopener noreferrer"
+  >Here a complete guide</a>
+  </p>
+</p>
+<h2 id="general-usage">General usage</h2>
+<ul>
+  <li>
+    The columns are defined in the <strong>parent component</strong>.
+  </li>
+  <li>
+    The grid classes can be applied to the <code>.container</code> element.
+  </li>
+  <li>Firefox dev tools work amazing for grid creation.</li>
+</ul>
+
+    <div class="container grid-2">
+      <div>...</div>
+      <div>...</div>
+    </div>
+
+<p>Ordering is applied to the child item.</p>
+<h2 id="container">Container</h2>
+<h3 className="m-t-4">.container</h3>
+<p>This is the same container we use currently in Neptune.</p>
+
+      <div class="container">...</div>
+
+<h3 className="m-t-4">.container-10</h3>
+<p>This gets the same result as tipical .col-md-10 .col-md-offset-1 from Bootstrap</p>
+
+    <div className="container-10">...</div>
+
+<div className="container-10">
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">This is some content</div>
+</div>
+
+<h3 className="m-t-4">.container-10--md</h3>
+<p>If you need this layout only for desktop. Use this case.</p>
+
+    <div className="container-10--md">...</div>
+
+<div className="container-10--md">
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">This is some content</div>
+</div>
+
+<h3 className="m-t-4 m-b-2">Example to compare with Bootstrap grid: .col-md-10 .col-md-offset-1</h3>
+<div className="docs-item col-md-10 col-md-offset-1 pull-xs-none">This is some content</div>
+
+<h3 className="m-t-4">.container-8</h3>
+
+    <div className="container-8">...</div>
+
+<div className="container-8">
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">This is some content</div>
+</div>
+
+<h3 className="m-t-4">.container-8--md</h3>
+
+    <div className="container-8--md">...</div>
+
+<div className="container-8--md">
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">This is some content</div>
+</div>
+
+<h3 className="m-t-4">Example with Bootstrap grid: .col-md-8 .col-md-offset-2</h3>
+<div className="docs-item col-md-8 col-md-offset-2 pull-xs-none">This is some content</div>
+
+<h2 id="responsive-columns">Responsive columns</h2>
+<p>Basic simple system</p>
+<h3 className="m-t-4">.grid-2</h3>
+
+    <div className="grid-2">
+        <div>...</div>
+        <div>...</div>
+    </div>
+
+<div className="grid-2">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-2--sm</h3>
+<div className="grid-2--sm">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-2--md</h3>
+<div className="grid-2--md">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-2--lg</h3>
+<div className="grid-2--lg">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-3</h3>
+<div className="grid-3">
+  <div className="docs-item">
+    This is some long content. Lorem ipsum, dolor sit amet consectetur adipisicing elit. Corrupti
+    iure, commodi odio omnis, nihil beatae vero alias laboriosam necessitatibus repellendus officia
+    molestiae quisquam fugiat. Nostrum nisi optio necessitatibus beatae sint.
+  </div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-3--sm</h3>
+<div className="grid-3--sm">
+  <div className="docs-item">
+    This is some long content. Lorem ipsum, dolor sit amet consectetur adipisicing elit. Corrupti
+    iure, commodi odio omnis, nihil beatae vero alias laboriosam necessitatibus repellendus officia
+    molestiae quisquam fugiat. Nostrum nisi optio necessitatibus beatae sint.
+  </div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-3--md</h3>
+<div className="grid-3--md">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-3--lg</h3>
+<div className="grid-3--lg">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-4</h3>
+<div className="grid-4">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-4--sm</h3>
+<div className="grid-4--sm">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-4--md</h3>
+<div className="grid-4--md">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-4--lg</h3>
+<div className="grid-4--lg">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h2 className="m-t-4">Combined:</h2>
+<h3 className="m-t-4"> .grid-2 .grid-3--md .grid-4--lg</h3>
+<div className="grid-2 grid-3--md grid-4--lg">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.grid-4 .grid-3--md .grid-2--lg</h3>
+<div className="grid-4 grid-3--md grid-2--lg">
+  <div className="docs-item">
+    This is some long content. Lorem ipsum, dolor sit amet consectetur adipisicing elit. Corrupti
+    iure, commodi odio omnis, nihil beatae vero alias laboriosam necessitatibus repellendus officia
+    molestiae quisquam fugiat. Nostrum nisi optio necessitatibus beatae sint.
+  </div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h2 id="nesting">Nesting grids</h2>
+<p>It's totally fine to nest grids</p>
+
+    <div className="grid-2 gap">
+      <div>
+        ...
+        <div className="grid-2">
+          <div>...</div>
+          <div>...</div>
+        </div>
+      </div>
+      <div>...</div>
+    </div>
+
+<div className="grid-2 gap">
+  <div className="docs-item">
+    Item
+    <div className="grid-2">
+      <div className="docs-item">Item</div>
+      <div className="docs-item">Item</div>
+    </div>
+  </div>
+  <div className="docs-item">Item</div>
+</div>
+
+    <div className="container-8 grid-2">
+      <div>
+        ...
+        <div className="grid-2--md gap">
+          <div>...</div>
+          <div>...</div>
+        </div>
+      </div>
+      <div>...</div>
+    </div>
+
+<div className="container-8 grid-2">
+  <div className="docs-item">
+    Item
+    <div className="grid-2--md gap">
+      <div className="docs-item">Item</div>
+      <div className="docs-item">Item</div>
+    </div>
+  </div>
+  <div className="docs-item">Item</div>
+</div>
+
+<h2 id="rows">Rows</h2>
+<p>The rows are autoplaced. You don´t have to do anything.</p>
+
+    <div className="grid-3">
+      <div>...</div>
+      <div>...</div>
+      <div>...</div>
+      <div>...</div>
+    </div>
+
+<h3 className="m-t-4">.grid-3</h3>
+<div className="grid-3">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+
+<h2 id="gap" className="">
+  Gap
+</h2>
+<ul>
+  <li>
+    The <strong>default</strong> --gap is <strong>--size-16</strong> for mobile,
+    <strong>--size-24</strong> for desktop
+  </li>
+  <li>
+    The <strong>column</strong> --gap is <strong>1/12</strong>. Like a Bootstrap col size.
+  </li>
+</ul>
+
+    <div className="grid-2 gap">
+      <div>...</div>
+      <div>...</div>
+    </div>
+
+<h3 className="m-t-4">.gap</h3>
+<p>The default gap is for both columns and rows.</p>
+<div className="grid-2 gap">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+
+<h3 className="m-t-4">.gap--32</h3>
+<div className="grid-2 gap--32">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+<h3 className="m-t-4">.gap--column</h3>
+<p>Gap only for columns. The space is 1/12</p>
+
+    :root {
+      --gap: calc(100% / 12);
+    }
+
+
+    <div className="grid-2 gap--column">
+      <div className="docs-item">...</div>
+      <div className="docs-item">...</div>
+      <div className="docs-item">...</div>
+      <div className="docs-item">...</div>
+    </div>
+
+<div className="grid-2 gap--column">
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+  <div className="docs-item">Item</div>
+</div>
+
+<h2 id="reverse" className="">
+  Reverse
+</h2>
+<p>The reverse mode is only horizontal (by now).</p>
+<h3 className="m-t-4">.reverse</h3>
+
+    <div class="grid-n reverse">
+      <div>...</div>
+      <div>...</div>
+    </div>
+
+<div className="grid-2 reverse">
+  <span className="docs-item">1 item</span>
+  <span className="docs-item">2 item</span>
+</div>
+<div className="grid-3 reverse m-t-4">
+  <span className="docs-item">1 item</span>
+  <span className="docs-item">2 item</span>
+  <span className="docs-item">3 item</span>
+</div>
+<div className="grid-4 reverse m-t-4">
+  <span className="docs-item">1 item</span>
+  <span className="docs-item">2 item</span>
+  <span className="docs-item">3 item</span>
+  <span className="docs-item">4 item</span>
+</div>
+
+<h2 id="order">Ordering</h2>
+<p>
+  The class must be added to the <strong>child item</strong>
+</p>
+<h3 className="m-t-4">.order-1--mobile</h3>
+
+    <div className="grid-4--md">
+      <div>...</div>
+      <div>...</div>
+      <div className="order-1--mobile">...</div>
+      <div>...</div>
+    </div>
+
+<div className="grid-4--md">
+  <span className="docs-item">1 item</span>
+  <span className="docs-item">2 item</span>
+  <span className="docs-item order-1--mobile docs-highlight">
+    3 item. I want to be first on mobile
+  </span>
+  <span className="docs-item">4 item</span>
+</div>
+
+<h2 id="alignment" className="">
+  Alignment
+</h2>
+<p>Uses the same alignment utility classes as Flex System does</p>
+<h3 className="m-t-4">.align-items-start</h3>
+
+    <div className="grid-2 align-items-start">
+      <div className="docs-item">...</div>
+      <div className="docs-item">...</div>
+    </div>
+
+<div className="grid-2 align-items-start">
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">
+    This is some content. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tempor, lacus
+    vel consequat viverra, tellus orci aliquet ante, sed lacinia orci orci in dui. Pellentesque
+    pellentesque ultricies ex, ut faucibus orci finibus non. Phasellus blandit laoreet eros, eget
+    mattis sem lacinia vitae. Nam dignissim viverra metus et tincidunt
+  </div>
+</div>
+
+<h3 className="m-t-4">.align-items-center</h3>
+
+    <div className="grid-2 align-items-center">
+      <div className="docs-item">...</div>
+      <div className="docs-item">...</div>
+    </div>
+
+<div className="grid-2 align-items-center">
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">
+    This is some content. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tempor, lacus
+    vel consequat viverra, tellus orci aliquet ante, sed lacinia orci orci in dui. Pellentesque
+    pellentesque ultricies ex, ut faucibus orci finibus non. Phasellus blandit laoreet eros, eget
+    mattis sem lacinia vitae. Nam dignissim viverra metus et tincidunt
+  </div>
+</div>
+
+<h3 className="m-t-4">.align-items-end</h3>
+
+    <div className="grid-2 align-items-end">
+      <div className="docs-item">...</div>
+      <div className="docs-item">...</div>
+    </div>
+
+<div className="grid-2 align-items-end">
+  <div className="docs-item">This is some content</div>
+  <div className="docs-item">
+    This is some content. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tempor, lacus
+    vel consequat viverra, tellus orci aliquet ante, sed lacinia orci orci in dui. Pellentesque
+    pellentesque ultricies ex, ut faucibus orci finibus non. Phasellus blandit laoreet eros, eget
+    mattis sem lacinia vitae. Nam dignissi.
+  </div>
+</div>
+<h1 className="m-t-4">Labs</h1>
+<h2 id="common-patterns">Common patterns</h2>
+<p>Do we have common layout patterns?</p>
+
+<h3 className="m-t-4">.grid-sidebar</h3>
+
+    <div className="grid-sidebar">
+      <div>...</div>
+      <div>...</div>
+    </div>
+
+  <div className="grid-sidebar">
+      <div className="docs-item"></div>
+      <div className="docs-item"></div>
+  </div>
+</div>
+
+export const meta = {
+  name: 'Grid Layout',
+  size: '4KB',
+};

--- a/packages/docs/pages/css/GridLayout.mdx
+++ b/packages/docs/pages/css/GridLayout.mdx
@@ -59,7 +59,7 @@ import '../../../css/dist/css/grid-layout.css';
     href="https://css-tricks.com/snippets/css/complete-guide-grid/"
     target="_blank"
     rel="noopener noreferrer"
-  >Here a complete guide</a>
+  >Here's a complete guide</a>
 </p>
 
 <hr />
@@ -91,7 +91,7 @@ import '../../../css/dist/css/grid-layout.css';
     <div class="container">...</div>
 
 <h3 className="m-t-4">.container-10</h3>
-<p>This gets the same result as tipical .col-md-10 .col-md-offset-1 from Bootstrap</p>
+<p>This gets the same result as the typical .col-md-10 .col-md-offset-1 from Bootstrap</p>
 
     <div class="container-10">...</div>
 

--- a/packages/docs/pages/css/GridLayout.mdx
+++ b/packages/docs/pages/css/GridLayout.mdx
@@ -1,70 +1,69 @@
 import '../../../css/dist/css/grid-layout.css';
 
-<div className="container">
-  <p>
-    TW Grid layout system created for building modern web layouts easily.
-  </p>
-  <div className="grid-3 gap">
-    <ul className="m-t-4">
-      <li>
-        <a href="#general-usage">General usage</a>
-      </li>
-      <li>
-        <a href="#container">Container</a>
-      </li>
-      <li>
-        <a href="#responsive-columns">Responsive columns</a>
-      </li>
-      <li>
-        <a href="#nesting">Nesting grids</a>
-      </li>
-      <li>
-        <a href="#rows">Rows</a>
-      </li>
-      <li>
-        <a href="#gap">Gap</a>
-      </li>
-      <li>
-        <a href="#reverse">Reverse</a>
-      </li>
-      <li>
-        <a href="#order">Ordering</a>
-      </li>
-      <li>
-        <a href="#alignment">Alignment</a>
-      </li>
-      <li>
-        <a href="#common-patterns">Common patterns</a>
-      </li>
+<p>W Grid layout system created for building modern web layouts easily.</p>
+<div className="grid-3 gap">
+  <ul className="m-t-4">
+    <li>
+      <a href="#general-usage">General usage</a>
+    </li>
+    <li>
+      <a href="#container">Container</a>
+    </li>
+    <li>
+      <a href="#responsive-columns">Responsive columns</a>
+    </li>
+    <li>
+      <a href="#nesting">Nesting grids</a>
+    </li>
+    <li>
+      <a href="#rows">Rows</a>
+    </li>
+    <li>
+      <a href="#gap">Gap</a>
+    </li>
+    <li>
+      <a href="#reverse">Reverse</a>
+    </li>
+    <li>
+      <a href="#order">Ordering</a>
+    </li>
+    <li>
+      <a href="#alignment">Alignment</a>
+    </li>
+    <li>
+      <a href="#common-patterns">Common patterns</a>
+    </li>
+  </ul>
+  <div>
+    <h3>Pros</h3>
+    <ul>
+      <li>Lightweight. 4KB vs 15KB (Bootstrap grid system)</li>
+      <li>Simple to use</li>
+      <li>Custom system to our needs. Flexible</li>
+      <li>Easy reverse and ordering</li>
+      <li>Less code. Simple DOM.</li>
+      <li>Use of standard and modern code</li>
+      <li>Can be used in combination with other layout systems (Flex, cols system). It's not exclusive.</li>
     </ul>
-    <div>
-      <h3>Pros</h3>
-      <ul>
-        <li>Lightweight. 4KB vs 15KB (Bootstrap grid system)</li>
-        <li>Simple to use</li>
-        <li>Custom system to our needs. Flexible</li>
-        <li>Easy reverse and ordering</li>
-        <li>Less code. Simple DOM.</li>
-        <li>Use of standard and modern code</li>
-        <li>Can be used in combination with other layout systems (Flex, cols system). It's not exclusive.</li>
-      </ul>
-    </div>
-    <div>
-      <h3>Cons</h3>
-      <ul>
-        <li>Not supported in IE11</li>
-      </ul>
-    </div>
   </div>
-  <p>
-  <p><span>Want to know more about grid layout? </span>
+  <div>
+    <h3>Cons</h3>
+    <ul>
+      <li>Not supported in IE11</li>
+    </ul>
+  </div>
+</div>
+<p>
+<span>Want to know more about grid layout? </span>
   <a
     href="https://css-tricks.com/snippets/css/complete-guide-grid/"
     target="_blank"
     rel="noopener noreferrer"
   >Here a complete guide</a>
-  </p>
 </p>
+
+<hr />
+
 <h2 id="general-usage">General usage</h2>
 <ul>
   <li>
@@ -82,16 +81,19 @@ import '../../../css/dist/css/grid-layout.css';
     </div>
 
 <p>Ordering is applied to the child item.</p>
+
+<hr />
+
 <h2 id="container">Container</h2>
 <h3 className="m-t-4">.container</h3>
 <p>This is the same container we use currently in Neptune.</p>
 
-      <div class="container">...</div>
+    <div class="container">...</div>
 
 <h3 className="m-t-4">.container-10</h3>
 <p>This gets the same result as tipical .col-md-10 .col-md-offset-1 from Bootstrap</p>
 
-    <div className="container-10">...</div>
+    <div class="container-10">...</div>
 
 <div className="container-10">
   <div className="docs-item">This is some content</div>
@@ -102,7 +104,7 @@ import '../../../css/dist/css/grid-layout.css';
 <h3 className="m-t-4">.container-10--md</h3>
 <p>If you need this layout only for desktop. Use this case.</p>
 
-    <div className="container-10--md">...</div>
+    <div class="container-10--md">...</div>
 
 <div className="container-10--md">
   <div className="docs-item">This is some content</div>
@@ -115,7 +117,7 @@ import '../../../css/dist/css/grid-layout.css';
 
 <h3 className="m-t-4">.container-8</h3>
 
-    <div className="container-8">...</div>
+    <div class="container-8">...</div>
 
 <div className="container-8">
   <div className="docs-item">This is some content</div>
@@ -125,7 +127,7 @@ import '../../../css/dist/css/grid-layout.css';
 
 <h3 className="m-t-4">.container-8--md</h3>
 
-    <div className="container-8--md">...</div>
+    <div class="container-8--md">...</div>
 
 <div className="container-8--md">
   <div className="docs-item">This is some content</div>
@@ -136,11 +138,13 @@ import '../../../css/dist/css/grid-layout.css';
 <h3 className="m-t-4">Example with Bootstrap grid: .col-md-8 .col-md-offset-2</h3>
 <div className="docs-item col-md-8 col-md-offset-2 pull-xs-none">This is some content</div>
 
+<hr />
+
 <h2 id="responsive-columns">Responsive columns</h2>
 <p>Basic simple system</p>
 <h3 className="m-t-4">.grid-2</h3>
 
-    <div className="grid-2">
+    <div class="grid-2">
         <div>...</div>
         <div>...</div>
     </div>
@@ -243,13 +247,16 @@ import '../../../css/dist/css/grid-layout.css';
   <div className="docs-item">Item</div>
   <div className="docs-item">Item</div>
 </div>
+
+<hr />
+
 <h2 id="nesting">Nesting grids</h2>
 <p>It's totally fine to nest grids</p>
 
-    <div className="grid-2 gap">
+    <div class="grid-2 gap">
       <div>
         ...
-        <div className="grid-2">
+        <div class="grid-2">
           <div>...</div>
           <div>...</div>
         </div>
@@ -257,7 +264,7 @@ import '../../../css/dist/css/grid-layout.css';
       <div>...</div>
     </div>
 
-<div className="grid-2 gap">
+<div className="grid-2 gap m-b-4">
   <div className="docs-item">
     Item
     <div className="grid-2">
@@ -268,10 +275,10 @@ import '../../../css/dist/css/grid-layout.css';
   <div className="docs-item">Item</div>
 </div>
 
-    <div className="container-8 grid-2">
+    <div class="container-8 grid-2">
       <div>
         ...
-        <div className="grid-2--md gap">
+        <div class="grid-2--md gap">
           <div>...</div>
           <div>...</div>
         </div>
@@ -290,17 +297,22 @@ import '../../../css/dist/css/grid-layout.css';
   <div className="docs-item">Item</div>
 </div>
 
+<hr />
+
 <h2 id="rows">Rows</h2>
 <p>The rows are autoplaced. You don´t have to do anything.</p>
 
-    <div className="grid-3">
+    <div class="grid-3">
       <div>...</div>
       <div>...</div>
       <div>...</div>
       <div>...</div>
     </div>
 
+
 <h3 className="m-t-4">.grid-3</h3>
+
+
 <div className="grid-3">
   <div className="docs-item">Item</div>
   <div className="docs-item">Item</div>
@@ -308,32 +320,37 @@ import '../../../css/dist/css/grid-layout.css';
   <div className="docs-item">Item</div>
 </div>
 
-<h2 id="gap" className="">
-  Gap
-</h2>
-<ul>
-  <li>
-    The <strong>default</strong> --gap is <strong>--size-16</strong> for mobile,
-    <strong>--size-24</strong> for desktop
-  </li>
-  <li>
-    The <strong>column</strong> --gap is <strong>1/12</strong>. Like a Bootstrap col size.
-  </li>
-</ul>
+<hr />
 
-    <div className="grid-2 gap">
+<h2 id="gap">Gap</h2>
+
+- The <strong>default</strong> --gap is <strong>--size-16</strong> for mobile,
+    <strong>--size-24</strong> for desktop
+- The <strong>column</strong> --gap is <strong>1/12</strong>. Like a Bootstrap col size.
+
+
+
+<h3 className="m-t-4">.gap</h3>
+
+<p>The default gap is for both columns and rows.</p>
+
+    <div class="grid-2 gap">
       <div>...</div>
       <div>...</div>
     </div>
 
-<h3 className="m-t-4">.gap</h3>
-<p>The default gap is for both columns and rows.</p>
-<div className="grid-2 gap">
+
+<div className="grid-2 gap m-b-4">
   <div className="docs-item">Item</div>
   <div className="docs-item">Item</div>
   <div className="docs-item">Item</div>
   <div className="docs-item">Item</div>
 </div>
+
+    <div class="grid-2 gap--32">
+      <div>...</div>
+      <div>...</div>
+    </div>
 
 <h3 className="m-t-4">.gap--32</h3>
 <div className="grid-2 gap--32">
@@ -342,19 +359,15 @@ import '../../../css/dist/css/grid-layout.css';
   <div className="docs-item">Item</div>
   <div className="docs-item">Item</div>
 </div>
+
 <h3 className="m-t-4">.gap--column</h3>
 <p>Gap only for columns. The space is 1/12</p>
 
-    :root {
-      --gap: calc(100% / 12);
-    }
-
-
-    <div className="grid-2 gap--column">
-      <div className="docs-item">...</div>
-      <div className="docs-item">...</div>
-      <div className="docs-item">...</div>
-      <div className="docs-item">...</div>
+    <div class="grid-2 gap--column">
+      <div class="docs-item">...</div>
+      <div class="docs-item">...</div>
+      <div class="docs-item">...</div>
+      <div class="docs-item">...</div>
     </div>
 
 <div className="grid-2 gap--column">
@@ -364,9 +377,9 @@ import '../../../css/dist/css/grid-layout.css';
   <div className="docs-item">Item</div>
 </div>
 
-<h2 id="reverse" className="">
-  Reverse
-</h2>
+<hr />
+
+<h2 id="reverse">Reverse</h2>
 <p>The reverse mode is only horizontal (by now).</p>
 <h3 className="m-t-4">.reverse</h3>
 
@@ -391,16 +404,18 @@ import '../../../css/dist/css/grid-layout.css';
   <span className="docs-item">4 item</span>
 </div>
 
+<hr />
+
 <h2 id="order">Ordering</h2>
 <p>
   The class must be added to the <strong>child item</strong>
 </p>
 <h3 className="m-t-4">.order-1--mobile</h3>
 
-    <div className="grid-4--md">
+    <div class="grid-4--md">
       <div>...</div>
       <div>...</div>
-      <div className="order-1--mobile">...</div>
+      <div class="order-1--mobile">...</div>
       <div>...</div>
     </div>
 
@@ -413,18 +428,18 @@ import '../../../css/dist/css/grid-layout.css';
   <span className="docs-item">4 item</span>
 </div>
 
-<h2 id="alignment" className="">
-  Alignment
-</h2>
+<hr />
+
+<h2 id="alignment">Alignment</h2>
 <p>Uses the same alignment utility classes as Flex System does</p>
 <h3 className="m-t-4">.align-items-start</h3>
 
-    <div className="grid-2 align-items-start">
-      <div className="docs-item">...</div>
-      <div className="docs-item">...</div>
+    <div class="grid-2 align-items-start">
+      <div class="docs-item">...</div>
+      <div class="docs-item">...</div>
     </div>
 
-<div className="grid-2 align-items-start">
+<div className="align-items-start grid-2">
   <div className="docs-item">This is some content</div>
   <div className="docs-item">
     This is some content. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tempor, lacus
@@ -436,9 +451,9 @@ import '../../../css/dist/css/grid-layout.css';
 
 <h3 className="m-t-4">.align-items-center</h3>
 
-    <div className="grid-2 align-items-center">
-      <div className="docs-item">...</div>
-      <div className="docs-item">...</div>
+    <div class="grid-2 align-items-center">
+      <div class="docs-item">...</div>
+      <div class="docs-item">...</div>
     </div>
 
 <div className="grid-2 align-items-center">
@@ -453,9 +468,9 @@ import '../../../css/dist/css/grid-layout.css';
 
 <h3 className="m-t-4">.align-items-end</h3>
 
-    <div className="grid-2 align-items-end">
-      <div className="docs-item">...</div>
-      <div className="docs-item">...</div>
+    <div class="grid-2 align-items-end">
+      <div class="docs-item">...</div>
+      <div class="docs-item">...</div>
     </div>
 
 <div className="grid-2 align-items-end">
@@ -467,22 +482,25 @@ import '../../../css/dist/css/grid-layout.css';
     mattis sem lacinia vitae. Nam dignissi.
   </div>
 </div>
+
+<hr />
+
 <h1 className="m-t-4">Labs</h1>
 <h2 id="common-patterns">Common patterns</h2>
 <p>Do we have common layout patterns?</p>
 
 <h3 className="m-t-4">.grid-sidebar</h3>
 
-    <div className="grid-sidebar">
+    <div class="grid-sidebar">
       <div>...</div>
       <div>...</div>
     </div>
 
-  <div className="grid-sidebar">
-      <div className="docs-item"></div>
-      <div className="docs-item"></div>
-  </div>
+<div className="grid-sidebar">
+    <div className="docs-item"></div>
+    <div className="docs-item"></div>
 </div>
+
 
 export const meta = {
   name: 'Grid Layout',

--- a/packages/docs/pages/css/GridLayout.mdx
+++ b/packages/docs/pages/css/GridLayout.mdx
@@ -1,6 +1,6 @@
 import '../../../css/dist/css/grid-layout.css';
 
-<p>W Grid layout system created for building modern web layouts easily.</p>
+<p>Grid layout system created for building modern web layouts easily.</p>
 <div className="grid-3 gap">
   <ul className="m-t-4">
     <li>

--- a/packages/docs/pages/css/GridLayout.mdx
+++ b/packages/docs/pages/css/GridLayout.mdx
@@ -72,7 +72,7 @@ import '../../../css/dist/css/grid-layout.css';
   <li>
     The grid classes can be applied to the <code>.container</code> element.
   </li>
-  <li>Firefox dev tools work amazing for grid creation.</li>
+  <li>Firefox dev tools work amazingly for grid creation.</li>
 </ul>
 
     <div class="container grid-2">

--- a/packages/docs/pages/css/Jumbotron.mdx
+++ b/packages/docs/pages/css/Jumbotron.mdx
@@ -1,0 +1,95 @@
+import '../../../css/dist/css/jumbotron.css';
+
+A lightweight, flexible component to create hero style components.
+
+<div class="jumbotron">
+  <h1>Hey wiser!</h1>
+  <p>
+    This is a simple hero unit, a simple jumbotron-style component for calling extra attention to
+    featured content or information.
+  </p>
+  <p>
+    <a class="btn btn-primary" href="#" role="button">
+      Learn more
+    </a>
+  </p>
+</div>
+
+    <div class="jumbotron">
+    ...
+    </div>
+
+To make the jumbotron full width, and without rounded corners, place it outside all <code>.container</code>s and instead add a <code>.container</code> within.
+
+    <div class="jumbotron">
+      <div class="container">
+        ...
+      </div>
+    </div>
+
+### Jumbotron with background image
+
+To provide a background image for a jumbotron unit, wrap the unit with <code> jumbotron-image</code>, you will need to specify an background image with CSS
+
+<div
+  class="jumbotron-image"
+  style={{
+    backgroundImage:
+      "url('https://daurzqvz85pz.cloudfront.net/55fabdde87a2a-testimonial_naila_background.png')",
+  }}
+>
+  <div class="jumbotron">
+    <h1>Hey wiser!</h1>
+    <p>
+      This is a simple hero unit, a simple jumbotron-style component for calling extra attention to
+      featured content or information.
+    </p>
+    <p>
+      <a class="btn btn-primary" href="#" role="button">
+        Learn more
+      </a>
+    </p>
+  </div>
+</div>
+
+    <div class="jumbotron-image" style="background-image: url('https://daurzqvz85pz.cloudfront.net/55fabdde87a2a-testimonial_naila_background.png')">
+      <div class="jumbotron">
+        ...
+      </div>
+    </div>
+
+### Jumbotron with background image inverse
+
+<div
+  class="jumbotron-image-inverse"
+  style={{
+    backgroundImage:
+      "url('https://daurzqvz85pz.cloudfront.net/55fabdde87a2a-testimonial_naila_background.png')",
+  }}
+>
+  <div class="jumbotron">
+    <h1>Hey wiser!</h1>
+    <p>
+      This is a simple hero unit, a simple jumbotron-style component for calling extra attention to
+      featured content or information.
+    </p>
+    <p>
+      <a class="btn btn-primary btn-lg" href="#" role="button">
+        Learn more
+      </a>
+    </p>
+  </div>
+</div>
+
+    <div class="jumbotron-image-inverse" style="background-image: url('https://daurzqvz85pz.cloudfront.net/55fabdde87a2a-testimonial_naila_background.png')">
+      <div class="jumbotron">
+        ...
+      </div>
+    </div>
+
+
+
+export const meta = {
+  name: 'Jumbotron',
+  size: '1KB',
+};

--- a/packages/docs/pages/css/Jumbotron.mdx
+++ b/packages/docs/pages/css/Jumbotron.mdx
@@ -2,22 +2,22 @@ import '../../../css/dist/css/jumbotron.css';
 
 A lightweight, flexible component to create hero style components.
 
-<div class="jumbotron">
+    <div class="jumbotron">
+    ...
+    </div>
+
+<div className="jumbotron">
   <h1>Hey wiser!</h1>
   <p>
     This is a simple hero unit, a simple jumbotron-style component for calling extra attention to
     featured content or information.
   </p>
   <p>
-    <a class="btn btn-primary" href="#" role="button">
+    <a className="btn btn-primary" href="#" role="button">
       Learn more
     </a>
   </p>
 </div>
-
-    <div class="jumbotron">
-    ...
-    </div>
 
 To make the jumbotron full width, and without rounded corners, place it outside all <code>.container</code>s and instead add a <code>.container</code> within.
 
@@ -27,54 +27,55 @@ To make the jumbotron full width, and without rounded corners, place it outside 
       </div>
     </div>
 
-### Jumbotron with background image
+## Jumbotron with background image
 
 To provide a background image for a jumbotron unit, wrap the unit with <code> jumbotron-image</code>, you will need to specify an background image with CSS
 
 <div
-  class="jumbotron-image"
+  className="jumbotron-image"
   style={{
     backgroundImage:
       "url('https://daurzqvz85pz.cloudfront.net/55fabdde87a2a-testimonial_naila_background.png')",
   }}
 >
-  <div class="jumbotron">
+
+    <div class="jumbotron-image" style="background-image: url('...')">
+      <div class="jumbotron">
+        ...
+      </div>
+    </div>
+
+  <div className="jumbotron">
     <h1>Hey wiser!</h1>
     <p>
       This is a simple hero unit, a simple jumbotron-style component for calling extra attention to
       featured content or information.
     </p>
     <p>
-      <a class="btn btn-primary" href="#" role="button">
+      <a className="btn btn-primary" href="#" role="button">
         Learn more
       </a>
     </p>
   </div>
 </div>
 
-    <div class="jumbotron-image" style="background-image: url('https://daurzqvz85pz.cloudfront.net/55fabdde87a2a-testimonial_naila_background.png')">
-      <div class="jumbotron">
-        ...
-      </div>
-    </div>
-
-### Jumbotron with background image inverse
+## Jumbotron with background image inverse
 
 <div
-  class="jumbotron-image-inverse"
+  className="jumbotron-image-inverse"
   style={{
     backgroundImage:
       "url('https://daurzqvz85pz.cloudfront.net/55fabdde87a2a-testimonial_naila_background.png')",
   }}
 >
-  <div class="jumbotron">
+  <div className="jumbotron">
     <h1>Hey wiser!</h1>
     <p>
       This is a simple hero unit, a simple jumbotron-style component for calling extra attention to
       featured content or information.
     </p>
     <p>
-      <a class="btn btn-primary btn-lg" href="#" role="button">
+      <a className="btn btn-primary btn-lg" href="#" role="button">
         Learn more
       </a>
     </p>
@@ -86,8 +87,6 @@ To provide a background image for a jumbotron unit, wrap the unit with <code> ju
         ...
       </div>
     </div>
-
-
 
 export const meta = {
   name: 'Jumbotron',

--- a/packages/docs/pages/css/Pagination.mdx
+++ b/packages/docs/pages/css/Pagination.mdx
@@ -1,0 +1,204 @@
+Provide pagination links for your site or app with the multi-page pagination component.
+
+<h2 id="pagination-default">Default pagination</h2>
+
+<nav>
+  <ul class="pagination">
+    <li>
+      <a href="#">1</a>
+    </li>
+    <li>
+      <a href="#">2</a>
+    </li>
+    <li>
+      <a href="#">3</a>
+    </li>
+    <li>
+      <a href="#">4</a>
+    </li>
+    <li>
+      <a href="#">5</a>
+    </li>
+  </ul>
+</nav>
+
+    <nav>
+      <ul class="pagination">
+        <li>
+          <a href="#">1</a>
+        </li>
+        <li>
+          <a href="#">2</a>
+        </li>
+        <li>
+          <a href="#">3</a>
+        </li>
+        <li>
+          <a href="#">4</a>
+        </li>
+        <li>
+          <a href="#">5</a>
+        </li>
+      </ul>
+    </nav>
+
+<h3>Disabled and active states</h3>
+<p>
+  Links are customizable for different circumstances. Use <code>.disabled</code> for unclickable
+  links and <code>.active</code> to indicate the current page.
+</p>
+
+<nav>
+  <ul class="pagination">
+    <li class="disabled">
+      <a href="#" aria-label="Previous">
+        <span aria-hidden="true">
+          <i class="glyphicon glyphicon-chevron-left"></i>
+        </span>
+      </a>
+    </li>
+    <li class="active">
+      <span>
+        1 <span class="sr-only">(current)</span>
+      </span>
+    </li>
+    <li>
+      <a href="#">2</a>
+    </li>
+    <li>
+      <a href="#">3</a>
+    </li>
+    <li>
+      <a href="#">4</a>
+    </li>
+    <li>
+      <a href="#">5</a>
+    </li>
+    <li>
+      <a href="#" aria-label="Next">
+        <span aria-hidden="true">
+          <i class="glyphicon glyphicon-chevron-right"></i>
+        </span>
+      </a>
+    </li>
+  </ul>
+</nav>
+
+    <nav>
+      <ul class="pagination">
+        <li class="active">
+          <span>1 <span class="sr-only">(current)</span></span>
+        </li>
+        <li>
+          <a href="">2 <span class="sr-only">(current)</span></a>
+        </li>
+        <li>
+          <span>...</span>
+        </li>
+        <li class="active">
+          <a href="">2 </a>
+        </li>
+      </ul>
+    </nav>
+
+You can optionally swap out active or disabled anchors for <code>&lt;span&gt;</code>, or omit the anchor in the case of the previous/next arrows, to remove click functionality while retaining intended styles.
+
+<nav>
+  <ul class="pagination">
+    <li class="active">
+      <span>
+        1 <span class="sr-only">(current)</span>
+      </span>
+    </li>
+    <li>
+      <a href="">2</a>
+    </li>
+    <li>
+      <span>...</span>
+    </li>
+    <li>
+      <a href="">12</a>
+    </li>
+  </ul>
+</nav>
+
+    <nav>
+      <ul class="pagination">
+        <li class="active">
+          <span>1 <span class="sr-only">(current)</span></span>
+        </li>
+        <li>
+          <a href="">2</a>
+        </li>
+        <li>
+          <span>...</span>
+        </li>
+        <li>
+          <a href="">12</a>
+        </li>
+      </ul>
+    </nav>
+
+<h3 id="pagination-text">Pagination text</h3>
+<p>
+  Our pagination will normally be associated with <code>.pagination-text</code>
+  to describe what is visualised and the total available.
+</p>
+
+<div class="clearfix text-xs-center">
+  <div class="pagination-text pull-md-left text-md-left">
+    Showing <strong>1 &ndash; 10</strong> of <strong>120</strong>.
+  </div>
+  <nav class="pull-md-right text-md-right">
+    <ul class="pagination">
+      <li class="active">
+        <a href="#">1</a>
+      </li>
+      <li>
+        <a href="#">2</a>
+      </li>
+      <li>
+        <a href="#">3</a>
+      </li>
+      <li>
+        <span>...</span>
+      </li>
+      <li>
+        <a href="#">12</a>
+      </li>
+    </ul>
+  </nav>
+</div>
+
+    <div class="text-xs-center">
+      <div class="pagination-text pull-md-left text-md-left">
+        Showing <strong>1 &ndash; 10</strong> of <strong>120</strong>.
+      </div>
+      <nav class="pull-md-right text-md-right">
+        <ul class="pagination">...</ul>
+      </nav>
+    </div>
+
+<h3 id="pagination-inverse">Inverse</h3>
+<p>On grey backgrounds we invert our hover states, add <code>.pagination-inverse</code> for additional styles.</p>
+
+
+  <nav class="bg-default p-a-4 m-b-4">
+    <ul class="pagination pagination-inverse">
+      <li class="active"><a href="#">1</a></li>
+      <li><a href="#">2</a></li>
+      <li><a href="#">3</a></li>
+      <li><span>...</span></li>
+      <li><a href="#">12</a></li>
+    </ul>
+  </nav>
+ 
+
+    <nav>
+      <ul class="pagination pagination-inverse">...</ul>
+    </nav>
+
+export const meta = {
+  name: 'Pagination',
+  size: '1KB',
+};

--- a/packages/docs/pages/css/Pagination.mdx
+++ b/packages/docs/pages/css/Pagination.mdx
@@ -1,9 +1,11 @@
+import '../../../css/dist/css/pagination.css';
+
 Provide pagination links for your site or app with the multi-page pagination component.
 
 <h2 id="pagination-default">Default pagination</h2>
 
 <nav>
-  <ul class="pagination">
+  <ul className="pagination">
     <li>
       <a href="#">1</a>
     </li>
@@ -49,17 +51,17 @@ Provide pagination links for your site or app with the multi-page pagination com
 </p>
 
 <nav>
-  <ul class="pagination">
-    <li class="disabled">
+  <ul className="pagination">
+    <li className="disabled">
       <a href="#" aria-label="Previous">
         <span aria-hidden="true">
-          <i class="glyphicon glyphicon-chevron-left"></i>
+          <i className="glyphicon glyphicon-chevron-left"></i>
         </span>
       </a>
     </li>
-    <li class="active">
+    <li className="active">
       <span>
-        1 <span class="sr-only">(current)</span>
+        1 <span className="sr-only">(current)</span>
       </span>
     </li>
     <li>
@@ -77,7 +79,7 @@ Provide pagination links for your site or app with the multi-page pagination com
     <li>
       <a href="#" aria-label="Next">
         <span aria-hidden="true">
-          <i class="glyphicon glyphicon-chevron-right"></i>
+          <i className="glyphicon glyphicon-chevron-right"></i>
         </span>
       </a>
     </li>
@@ -104,10 +106,10 @@ Provide pagination links for your site or app with the multi-page pagination com
 You can optionally swap out active or disabled anchors for <code>&lt;span&gt;</code>, or omit the anchor in the case of the previous/next arrows, to remove click functionality while retaining intended styles.
 
 <nav>
-  <ul class="pagination">
-    <li class="active">
+  <ul className="pagination">
+    <li className="active">
       <span>
-        1 <span class="sr-only">(current)</span>
+        1 <span className="sr-only">(current)</span>
       </span>
     </li>
     <li>
@@ -145,13 +147,13 @@ You can optionally swap out active or disabled anchors for <code>&lt;span&gt;</c
   to describe what is visualised and the total available.
 </p>
 
-<div class="clearfix text-xs-center">
-  <div class="pagination-text pull-md-left text-md-left">
+<div className="clearfix text-xs-center">
+  <div className="pagination-text pull-md-left text-md-left">
     Showing <strong>1 &ndash; 10</strong> of <strong>120</strong>.
   </div>
-  <nav class="pull-md-right text-md-right">
-    <ul class="pagination">
-      <li class="active">
+  <nav className="pull-md-right text-md-right">
+    <ul className="pagination">
+      <li className="active">
         <a href="#">1</a>
       </li>
       <li>
@@ -182,10 +184,9 @@ You can optionally swap out active or disabled anchors for <code>&lt;span&gt;</c
 <h3 id="pagination-inverse">Inverse</h3>
 <p>On grey backgrounds we invert our hover states, add <code>.pagination-inverse</code> for additional styles.</p>
 
-
-  <nav class="bg-default p-a-4 m-b-4">
-    <ul class="pagination pagination-inverse">
-      <li class="active"><a href="#">1</a></li>
+  <nav className="bg-default p-a-4 m-b-4">
+    <ul className="pagination pagination-inverse">
+      <li className="active"><a href="#">1</a></li>
       <li><a href="#">2</a></li>
       <li><a href="#">3</a></li>
       <li><span>...</span></li>
@@ -193,7 +194,6 @@ You can optionally swap out active or disabled anchors for <code>&lt;span&gt;</c
     </ul>
   </nav>
  
-
     <nav>
       <ul class="pagination pagination-inverse">...</ul>
     </nav>

--- a/packages/docs/static/assets/main.less
+++ b/packages/docs/static/assets/main.less
@@ -1,5 +1,3 @@
-@import '@transferwise/neptune-css/src/less/neptune-tokens.less';
-
 /* Typography */
 
 h1[id] + p,
@@ -10,8 +8,8 @@ h1.colored-dot + p {
 h2[id],
 h2.docs-heading,
 p + h2[id] {
-  margin-top: var(--space-48);
-  margin-bottom: var(--space-8);
+  margin-top: var(--size-48);
+  margin-bottom: var(--size-8);
 }
 
 /* Layout  */
@@ -36,7 +34,7 @@ p + h2[id] {
 .Logo img {
   height: 16px;
   max-width: none;
-  margin: var(--space-24);
+  margin: var(--size-24);
 }
 
 .Sidebar__Fixed {
@@ -53,7 +51,7 @@ p + h2[id] {
 }
 
 .Sidebar__Header {
-  padding: 20px var(--space-16);
+  padding: 20px var(--size-16);
 }
 
 .Sidebar__Inner {
@@ -64,7 +62,7 @@ p + h2[id] {
 }
 
 .Sidebar__Search {
-  padding: var(--space-8) var(--space-16);
+  padding: var(--size-8) var(--size-16);
 
   color: #37517e;
   border: none;
@@ -89,7 +87,7 @@ p + h2[id] {
 .Nav__Link {
   display: block;
 
-  padding: var(--space-8) var(--space-16);
+  padding: var(--size-8) var(--size-16);
 
   transition: color 0.15s;
   text-decoration: none;
@@ -117,7 +115,7 @@ p + h2[id] {
 }
 
 .Nav__Group {
-  padding: var(--space-16) var(--space-16) var(--space-8);
+  padding: var(--size-16) var(--size-16) var(--size-8);
 
   text-transform: uppercase;
 
@@ -132,7 +130,7 @@ p + h2[id] {
 }
 
 .Sidebar .Nav > .Nav__Group:not(:first-of-type) {
-  margin-top: var(--space-24);
+  margin-top: var(--size-24);
 }
 
 .Nav--dark .Nav__Link {
@@ -151,7 +149,7 @@ p + h2[id] {
 
   width: 100%;
   min-height: 100vh;
-  padding: var(--space-32);
+  padding: var(--size-32);
 
   background: #fff;
 }
@@ -159,7 +157,7 @@ p + h2[id] {
 @media (min-width: 767px) {
   .Content {
     max-width: 1012px;
-    padding: var(--space-32) var(--space-40);
+    padding: var(--size-32) var(--size-40);
   }
 }
 
@@ -176,7 +174,7 @@ img {
 
 /* Live editor */
 .live-provider {
-  margin: calc(var(--spacer) * 3) 0 0;
+  margin: calc(var(--sizer) * 3) 0 0;
 }
 
 .live-editor {
@@ -187,7 +185,7 @@ img {
 
 @media (min-width: 1200px) {
   .live-preview {
-    padding-left: calc(var(--spacer) * 4);
+    padding-left: calc(var(--sizer) * 4);
   }
 }
 
@@ -211,17 +209,17 @@ img {
 
 .docs-table > thead > tr > td,
 .docs-table > thead > tr > th {
-  padding: calc(var(--spacer) * 2) calc(var(--spacer) * 3) !important;
+  padding: calc(var(--sizer) * 2) calc(var(--sizer) * 3) !important;
 }
 
 .docs-table > tbody > tr > td,
 .docs-table > tbody > tr > th {
-  padding: calc(var(--spacer) * 3) calc(var(--spacer) * 3) !important;
+  padding: calc(var(--sizer) * 3) calc(var(--sizer) * 3) !important;
 }
 
 .docs-table .table-condensed > tbody > tr > td,
 .docs-table .table-condensed > tbody > tr > th {
-  padding: calc(var(--spacer) * 2) calc(var(--spacer) * 3) !important;
+  padding: calc(var(--sizer) * 2) calc(var(--sizer) * 3) !important;
 }
 
 .docs-table > thead {
@@ -236,7 +234,7 @@ img {
 }
 
 .docs-table ul {
-  margin-bottom: var(--spacer);
+  margin-bottom: var(--sizer);
   padding: 0;
 }
 

--- a/packages/docs/static/assets/main.less
+++ b/packages/docs/static/assets/main.less
@@ -1,3 +1,10 @@
+@import '@transferwise/neptune-css/dist/props/neptune-tokens.css';
+@import '@transferwise/neptune-css/dist/props/legacy-custom-props.css';
+
+html {
+  scroll-behavior: smooth;
+}
+
 /* Typography */
 
 h1[id] + p,
@@ -174,7 +181,7 @@ img {
 
 /* Live editor */
 .live-provider {
-  margin: calc(var(--sizer) * 3) 0 0;
+  margin: calc(var(--size) * 3) 0 0;
 }
 
 .live-editor {
@@ -185,7 +192,7 @@ img {
 
 @media (min-width: 1200px) {
   .live-preview {
-    padding-left: calc(var(--sizer) * 4);
+    padding-left: calc(var(--size) * 4);
   }
 }
 
@@ -209,17 +216,17 @@ img {
 
 .docs-table > thead > tr > td,
 .docs-table > thead > tr > th {
-  padding: calc(var(--sizer) * 2) calc(var(--sizer) * 3) !important;
+  padding: calc(var(--size) * 2) calc(var(--size) * 3) !important;
 }
 
 .docs-table > tbody > tr > td,
 .docs-table > tbody > tr > th {
-  padding: calc(var(--sizer) * 3) calc(var(--sizer) * 3) !important;
+  padding: calc(var(--size) * 3) calc(var(--size) * 3) !important;
 }
 
 .docs-table .table-condensed > tbody > tr > td,
 .docs-table .table-condensed > tbody > tr > th {
-  padding: calc(var(--sizer) * 2) calc(var(--sizer) * 3) !important;
+  padding: calc(var(--size) * 2) calc(var(--size) * 3) !important;
 }
 
 .docs-table > thead {
@@ -234,7 +241,7 @@ img {
 }
 
 .docs-table ul {
-  margin-bottom: var(--sizer);
+  margin-bottom: var(--size);
   padding: 0;
 }
 
@@ -245,4 +252,32 @@ img {
 .docs-is-visible {
   color: #468847;
   background-color: #dff0d8 !important;
+}
+
+.docs-box-dashed {
+  border: 1px dashed #829ca9;
+}
+
+.docs-bg {
+  height: 400px;
+  background-attachment: scroll !important;
+}
+
+.docs-item {
+  padding: var(--size-16);
+  background-color: var(--color-background-neutral);
+  border: 1px solid var(--color-text-secondary);
+}
+
+.docs-item.docs-highlight {
+  color: white;
+  background: var(--color-text-important);
+}
+
+/* 🥚 */
+
+@media (--screen-sm-max) {
+  .order-1--mobile::after {
+    content: ' 🎉';
+  }
 }

--- a/packages/docs/static/assets/main.less
+++ b/packages/docs/static/assets/main.less
@@ -181,7 +181,7 @@ img {
 
 /* Live editor */
 .live-provider {
-  margin: calc(var(--size) * 3) 0 0;
+  margin: var(--size-24) 0 0;
 }
 
 .live-editor {
@@ -192,7 +192,7 @@ img {
 
 @media (min-width: 1200px) {
   .live-preview {
-    padding-left: calc(var(--size) * 4);
+    padding-left: var(--size-32);
   }
 }
 
@@ -216,17 +216,17 @@ img {
 
 .docs-table > thead > tr > td,
 .docs-table > thead > tr > th {
-  padding: calc(var(--size) * 2) calc(var(--size) * 3) !important;
+  padding: var(--size-16) var(--size-24) !important;
 }
 
 .docs-table > tbody > tr > td,
 .docs-table > tbody > tr > th {
-  padding: calc(var(--size) * 3) calc(var(--size) * 3) !important;
+  padding: var(--size-24) var(--size-24) !important;
 }
 
 .docs-table .table-condensed > tbody > tr > td,
 .docs-table .table-condensed > tbody > tr > th {
-  padding: calc(var(--size) * 2) calc(var(--size) * 3) !important;
+  padding: var(--size-16) var(--size-24) !important;
 }
 
 .docs-table > thead {
@@ -241,7 +241,7 @@ img {
 }
 
 .docs-table ul {
-  margin-bottom: var(--size);
+  margin-bottom: var(--size-8);
   padding: 0;
 }
 

--- a/packages/docs/utils/sections.js
+++ b/packages/docs/utils/sections.js
@@ -36,4 +36,9 @@ export default [
     ],
     searchable: true,
   },
+
+  {
+    title: 'CSS',
+    dir: 'css',
+  },
 ];

--- a/packages/marketing-components/package.json
+++ b/packages/marketing-components/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "@transferwise/icons": "^2.4.1",
-    "@transferwise/neptune-css": "^2.1.2",
+    "@transferwise/neptune-css": "^4.0.5",
     "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1"

--- a/packages/marketing-components/src/videomodal/VideoModal.less
+++ b/packages/marketing-components/src/videomodal/VideoModal.less
@@ -1,4 +1,4 @@
-@import (reference) '@transferwise/neptune-css/src/less/variables/legacy-variables.less';
+@import (reference) '@transferwise/neptune-css/dist/less/legacy-variables.less';
 @import (less) '@reach/dialog/styles.css';
 
 .twmc-video-modal__overlay {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -9,14 +9,12 @@ module.exports = {
     'postcss-import': {},
     autoprefixer: {},
     '@arshaw/postcss-custom-properties': {
-      importFrom: [
-        '../../node_modules/@transferwise/neptune-tokens/colors.css',
-        '../../node_modules/@transferwise/neptune-tokens/spacing.css',
-      ],
+      importFrom: ['../../node_modules/@transferwise/neptune-tokens/tokens.css'],
       preserveWithFallback: true,
     },
     'postcss-custom-media': {
       stage: 1,
+      importFrom: ['../../node_modules/@transferwise/neptune-css/dist/props/custom-media.css'],
     },
     cssnano: {
       preset: 'default',

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -9,7 +9,7 @@ module.exports = {
     'postcss-import': {},
     autoprefixer: {},
     '@arshaw/postcss-custom-properties': {
-      importFrom: ['../../node_modules/@transferwise/neptune-tokens/tokens.css'],
+      importFrom: ['../../node_modules/@transferwise/neptune-css/dist/props/neptune-tokens.css'],
       preserveWithFallback: true,
     },
     'postcss-custom-media': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3808,15 +3808,6 @@
     stylelint-config-standard "^20.0.0"
     stylelint-value-no-unknown-custom-properties "^3.0.0"
 
-"@transferwise/neptune-css@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@transferwise/neptune-css/-/neptune-css-2.1.2.tgz#d04e6cecbe56d3adc621c42e0ea1fb19fc64b87b"
-  integrity sha512-t/N5qXq7i3ZsnHmGPkVHxn31QD9P4uSxEAYaUinYhMfDTJudzKQQhrZ4g+LcqJQMeyDF1LxUsN+bg8tsFElqow==
-  dependencies:
-    "@transferwise/neptune-tokens" "^0.1.0"
-    bootstrap "github:transferwise/bootstrap#semver:^5.20.0"
-    svgo "1.3.2"
-
 "@transferwise/neptune-css@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@transferwise/neptune-css/-/neptune-css-4.0.5.tgz#ff342d2b4136c3f485ec0c072980a640f9848967"
@@ -3825,11 +3816,6 @@
     "@transferwise/neptune-tokens" "^1.0.0"
     bootstrap "github:transferwise/bootstrap#semver:^5.20.0"
     svgo "1.3.2"
-
-"@transferwise/neptune-tokens@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@transferwise/neptune-tokens/-/neptune-tokens-0.1.0.tgz#0d5080c00a0dc2c4034b97da40a08655368391a9"
-  integrity sha512-XbLXGGO53p/ISPWQC92Jju80MrMH9LhNs1Fuz1u52Dgzsi67EsFJGDVTgIc24poVpmxsvYyV1kOOM1jDJgeDIw==
 
 "@transferwise/neptune-tokens@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3782,32 +3782,6 @@
     stylelint-config-standard "^20.0.0"
     stylelint-value-no-unknown-custom-properties "^3.0.0"
 
-"@transferwise/less-config@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@transferwise/less-config/-/less-config-3.0.0.tgz#ca841b1d3b58ec06279b641a2db9bdb51a2d007b"
-  integrity sha512-AyR4c4GBAI2aOBSkK1VHwBT5kW2SqHF5cj7tOL3p/4jlCjvyyJaYi39TiYWe0kiFub4P07dIVQgl/DgOQ1/wyg==
-  dependencies:
-    "@arshaw/postcss-custom-properties" "^9.1.1"
-    autoprefixer "^9.7.6"
-    cssnano "^4.1.10"
-    gulp "^4.0.2"
-    gulp-cached "^1.1.1"
-    gulp-cssimport "^7.0.0"
-    gulp-dependents "^1.2.3"
-    gulp-filter "^6.0.0"
-    gulp-if "^3.0.0"
-    gulp-less "^4.0.1"
-    gulp-plumber "^1.2.1"
-    gulp-postcss "^8.0.0"
-    gulp-print "^5.0.2"
-    gulp-rename "^2.0.0"
-    postcss-custom-media "^7.0.8"
-    postcss-custom-properties "^9.0.2"
-    postcss-import "^12.0.1"
-    stylelint "^13.6.1"
-    stylelint-config-standard "^20.0.0"
-    stylelint-value-no-unknown-custom-properties "^3.0.0"
-
 "@transferwise/neptune-css@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@transferwise/neptune-css/-/neptune-css-4.0.5.tgz#ff342d2b4136c3f485ec0c072980a640f9848967"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3777,6 +3777,32 @@
     stylelint-config-standard "^20.0.0"
     stylelint-value-no-unknown-custom-properties "^3.0.0"
 
+"@transferwise/less-config@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@transferwise/less-config/-/less-config-3.0.0.tgz#ca841b1d3b58ec06279b641a2db9bdb51a2d007b"
+  integrity sha512-AyR4c4GBAI2aOBSkK1VHwBT5kW2SqHF5cj7tOL3p/4jlCjvyyJaYi39TiYWe0kiFub4P07dIVQgl/DgOQ1/wyg==
+  dependencies:
+    "@arshaw/postcss-custom-properties" "^9.1.1"
+    autoprefixer "^9.7.6"
+    cssnano "^4.1.10"
+    gulp "^4.0.2"
+    gulp-cached "^1.1.1"
+    gulp-cssimport "^7.0.0"
+    gulp-dependents "^1.2.3"
+    gulp-filter "^6.0.0"
+    gulp-if "^3.0.0"
+    gulp-less "^4.0.1"
+    gulp-plumber "^1.2.1"
+    gulp-postcss "^8.0.0"
+    gulp-print "^5.0.2"
+    gulp-rename "^2.0.0"
+    postcss-custom-media "^7.0.8"
+    postcss-custom-properties "^9.0.2"
+    postcss-import "^12.0.1"
+    stylelint "^13.6.1"
+    stylelint-config-standard "^20.0.0"
+    stylelint-value-no-unknown-custom-properties "^3.0.0"
+
 "@transferwise/neptune-css@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@transferwise/neptune-css/-/neptune-css-2.1.2.tgz#d04e6cecbe56d3adc621c42e0ea1fb19fc64b87b"
@@ -3786,10 +3812,24 @@
     bootstrap "github:transferwise/bootstrap#semver:^5.20.0"
     svgo "1.3.2"
 
+"@transferwise/neptune-css@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@transferwise/neptune-css/-/neptune-css-4.0.5.tgz#ff342d2b4136c3f485ec0c072980a640f9848967"
+  integrity sha512-cZps68uJ9/GxvZazawDyFYszDSLDD3EHODB4A+PX95o9jDcsvZaI0B5syU4s8fJzBCaeJ2wGMniYF5sSNEAVKg==
+  dependencies:
+    "@transferwise/neptune-tokens" "^1.0.0"
+    bootstrap "github:transferwise/bootstrap#semver:^5.20.0"
+    svgo "1.3.2"
+
 "@transferwise/neptune-tokens@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@transferwise/neptune-tokens/-/neptune-tokens-0.1.0.tgz#0d5080c00a0dc2c4034b97da40a08655368391a9"
   integrity sha512-XbLXGGO53p/ISPWQC92Jju80MrMH9LhNs1Fuz1u52Dgzsi67EsFJGDVTgIc24poVpmxsvYyV1kOOM1jDJgeDIw==
+
+"@transferwise/neptune-tokens@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@transferwise/neptune-tokens/-/neptune-tokens-1.0.0.tgz#c919ae2492776c0a74a56cfab1a8fe03cab09830"
+  integrity sha512-F35PjYU4iI0de5l67vAa1u01hezzkmLtAIf1snnNQWfoOxJieTvn9lgsG9nHdySKhFhMBXq+60UUTwRLGxGW1Q==
 
 "@transferwise/test-config@^1.0.5":
   version "1.0.5"
@@ -15731,6 +15771,11 @@ prism-react-renderer@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.0.2.tgz#3bb9a6a42f76fc049b03266298c7068fdd4b7ea9"
   integrity sha512-0++pJyRfu4v2OxI/Us/5RLui9ESDkTiLkVCtKuPZYdpB8UQWJpnJQhPrWab053XtsKW3oM0sD69uJ6N9exm1Ag==
+
+prism-react-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz#1c1be61b1eb9446a146ca7a50b7bcf36f2a70a44"
+  integrity sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==
 
 prismjs@^1.8.4:
   version "1.18.0"


### PR DESCRIPTION
Ticket: https://transferwise.atlassian.net/browse/OG-3646
[Here the demo](https://transferwise.github.io/marketing-components/branch/css-package/css/About)

- This PR adds a new package to the monorepo with marketing oriented CSS components. 
These componets are particularly used in public marketing pages and some of them have been deprecated from general neptune-css bundle, which has a product orientation, but we need to keep them because they are being used in production in some projets.
Other components, as the Grid Layout system, it's brand new for marketing purposes, a lightweight simple way to create layouts. 

- Bump to last neptune-css & icons versions.

feat: Add CSS package 87da1cb
docs: add documentation for css components fc4a25c
docs: layout minor changes eac01d9
chore: bump neptune-css and icons to last release  1581e1b 

![imagen](https://user-images.githubusercontent.com/1814752/97690656-306f9380-1a95-11eb-9d53-676d1dee503c.png)


## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/neptune-web/blob/master/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [ ] Changes are tested and all tests pass
- [ ] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
- [ ] Change has been approved by someone outside of your team
