### PR TITLE
feat: Add ClosableBlock component

### DIFF
--- a/packages/marketing-components/.storybook/main.js
+++ b/packages/marketing-components/.storybook/main.js
@@ -1,0 +1,53 @@
+const path = require('path');
+
+const isPostcssLoader = (l) =>
+  l === 'postcss-loader' || (l.loader && l.loader.includes('postcss-loader'));
+
+const ruleHasPostcssLoader = (r) => {
+  const loadersWithPostCss =
+    r.hasOwnProperty('use') && Array.isArray(r.use) && r.use.filter(isPostcssLoader);
+  if (loadersWithPostCss.length) return true;
+  return false;
+};
+
+module.exports = {
+  webpackFinal: async (config) => {
+    console.log(config.module.rules);
+
+    // Remove the existing css rule
+    config.module.rules = config.module.rules.flatMap((rule) => {
+      if (!ruleHasPostcssLoader(rule)) return [rule];
+
+      // For each rule found with postcss-loader in it, create an array of new rules to
+      // replace the one rule. The new array includes one rule for loaders before postcss,
+      // one rule for postcss that excludes node_modules, and (optionally) one rule for
+      // any loaders after postcss.
+
+      // Get the index of postcss-loader in the array of loaders
+      const postcssIndex = rule.use.findIndex(isPostcssLoader);
+
+      // Define new rules
+      return [
+        // Loaders before postcss-loader
+        {
+          ...rule,
+          use: rule.use.slice(0, postcssIndex),
+        },
+        // New postcss-loader
+        {
+          ...rule,
+          exclude: /node_modules/,
+          use: [rule.use[postcssIndex]],
+        },
+        // Append any loaders after postcss-loader
+        Boolean(rule.use.length > postcssIndex + 1) && {
+          ...rule,
+          use: rule.use.slice(postcssIndex + 1),
+        },
+      ].filter(Boolean);
+    });
+
+    // Return the altered config
+    return config;
+  },
+};

--- a/packages/marketing-components/package.json
+++ b/packages/marketing-components/package.json
@@ -12,6 +12,11 @@
   "files": [
     "build"
   ],
+  "browserslist": [
+    "last 2 versions",
+    "last 9 Chrome versions",
+    "IE 11"
+  ],
   "repository": {
     "type": "git",
     "fullname": "transferwise/marketing-components",
@@ -75,6 +80,8 @@
     "@reach/dialog": "^0.10.5",
     "@transferwise/cookie-consent": "^2.8.0",
     "classnames": "^2.2.6",
+    "postcss-flexbugs-fixes": "^5.0.1",
+    "postcss-preset-env": "^6.7.0",
     "react-spring": "^8.0.27"
   },
   "resolutions": {

--- a/packages/marketing-components/postcss.config.js
+++ b/packages/marketing-components/postcss.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  plugins: {
+    'postcss-preset-env': {
+      autoprefixer: {
+        flexbox: 'no-2009',
+        grid: 'autoplace',
+      },
+      stage: 1,
+    },
+  },
+};

--- a/packages/marketing-components/src/closableblock/ClosableBlock.js
+++ b/packages/marketing-components/src/closableblock/ClosableBlock.js
@@ -24,9 +24,9 @@ export default function ContentBlock(props) {
     }
 
     const mediaQuery = window.matchMedia('(min-width: 576px)');
-    mediaQuery.addEventListener('change', handleMediaMatchChange);
+    mediaQuery.addListener(handleMediaMatchChange);
 
-    return () => mediaQuery.removeEventListener('change', handleMediaMatchChange);
+    return () => mediaQuery.removeListener(handleMediaMatchChange);
   }, []);
 
   useIsomorphicEffect(() => {

--- a/packages/marketing-components/src/closableblock/ClosableBlock.js
+++ b/packages/marketing-components/src/closableblock/ClosableBlock.js
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import classnames from 'classnames';
+import Types from 'prop-types';
+import { Chevron as ChevronIcon } from '@transferwise/components';
+
+import './ClosableBlock.css';
+
+const useIsomorphicEffect = typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
+
+export default function ContentBlock(props) {
+  const { src, heading, body, headingLevel: HeadingComponent } = props;
+  const [isOpen, setOpen] = React.useState(false);
+  const [focusable, setFocusable] = React.useState(false);
+
+  React.useEffect(() => {
+    function handleMediaMatchChange(event) {
+      if (event.matches) {
+        setOpen(true);
+        setFocusable(false);
+      } else {
+        setOpen(false);
+        setFocusable(true);
+      }
+    }
+
+    const mediaQuery = window.matchMedia('(min-width: 576px)');
+    mediaQuery.addEventListener('change', handleMediaMatchChange);
+
+    return () => mediaQuery.removeEventListener('change', handleMediaMatchChange);
+  }, []);
+
+  useIsomorphicEffect(() => {
+    const { matches } = window.matchMedia('(min-width: 576px)');
+    setFocusable(!matches);
+    setOpen(matches);
+  }, []);
+
+  function getDynamicProps() {
+    if (!focusable) {
+      return {};
+    } else {
+      return {
+        type: 'button',
+        onClick: () => setOpen(!isOpen),
+        'aria-expanded': isOpen,
+      };
+    }
+  }
+
+  const Component = !focusable ? 'div' : 'button';
+  return (
+    <Component
+      className={classnames('tw-contentBlock', {
+        'tw-contentBlock--open': isOpen,
+      })}
+      {...getDynamicProps()}
+    >
+      <div className="tw-contentBlock__image">
+        <img src={src} alt="" />
+      </div>
+      <div className="tw-contentBlock__content">
+        <HeadingComponent className="tw-contentBlock__content__heading h4">
+          {heading}
+        </HeadingComponent>
+        <p
+          className="tw-contentBlock__content__body m-b-0 m-t-2"
+          hidden={isOpen ? undefined : 'hidden'}
+        >
+          {body}
+        </p>
+      </div>
+      <div className="tw-contentBlock__chevron">
+        <ChevronIcon size={ChevronIcon.Size.EXTRA_SMALL} />
+      </div>
+    </Component>
+  );
+}
+
+ContentBlock.propTypes = {
+  src: Types.string.isRequired,
+  heading: Types.node.isRequired,
+  headingLevel: Types.oneOf(['h2', 'h3', 'h4', 'h5']).isRequired,
+  body: Types.node.isRequired,
+};

--- a/packages/marketing-components/src/closableblock/ClosableBlock.less
+++ b/packages/marketing-components/src/closableblock/ClosableBlock.less
@@ -1,0 +1,73 @@
+.tw-contentBlock {
+  display: grid;
+  grid-template-columns: min-content 1fr min-content;
+  grid-template-rows: 1fr;
+  grid-gap: var(--size-16);
+  background-color: var(--color-background-screen);
+  width: auto;
+  border: 0;
+  outline: 0;
+  cursor: default;
+  align-items: start;
+  padding-top: var(--size-16);
+  padding-bottom: var(--size-16);
+  padding-left: var(--size-16);
+  padding-right: var(--size-16);
+  width: 100%;
+  border: 1px solid var(--color-border-neutral);
+}
+
+.tw-contentBlock__image {
+  width: 32px;
+  align-self: start;
+}
+
+.tw-contentBlock__content {
+  text-align: left;
+}
+
+.tw-contentBlock__content__heading {
+  margin-top: 6px;
+}
+
+.tw-contentBlock__chevron {
+  align-self: start;
+  margin-top: 6px;
+}
+
+.tw-contentBlock__chevron svg {
+  transition: transform 150ms;
+}
+
+.tw-contentBlock--open .tw-contentBlock__chevron svg {
+  transform: rotate(180deg);
+}
+
+@media (--screen-sm) {
+  .tw-contentBlock {
+    grid-template-columns: min-content 1fr;
+    padding-top: var(--size-24);
+    padding-bottom: var(--size-24);
+    padding-left: var(--size-24);
+    padding-right: var(--size-24);
+    grid-gap: var(--size-24);
+  }
+
+  // .tw-contentBlock:focus {
+  //   border: 1px solid var(--color-border-neutral);
+  //   outline: 0;
+  // }
+
+  .tw-contentBlock__image {
+    width: 64px;
+    align-self: center;
+  }
+
+  .tw-contentBlock__chevron {
+    display: none;
+  }
+
+  .tw-contentBlock__content__body {
+    display: block;
+  }
+}

--- a/packages/marketing-components/src/closableblock/ClosableBlock.less
+++ b/packages/marketing-components/src/closableblock/ClosableBlock.less
@@ -1,3 +1,10 @@
+.storyCSS {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr;
+  grid-gap: 1rem;
+}
+
 .tw-contentBlock {
   display: grid;
   grid-template-columns: min-content 1fr min-content;

--- a/packages/marketing-components/src/closableblock/ClosableBlock.spec.js
+++ b/packages/marketing-components/src/closableblock/ClosableBlock.spec.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/react';
+
+import ClosableBlock from './';
+
+describe('ClosableBlock', () => {
+  it('renders', () => {
+    expect.assertions(1);
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      })),
+    });
+
+    expect(() =>
+      render(
+        <ClosableBlock
+          headingLevel="h2"
+          heading="heading"
+          body="body"
+          src="https://transferwise.com/public-resources/assets/public-navigation/phone_number.svg"
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  describe('at small screen sizes', () => {
+    it('can be opened', () => {
+      expect.assertions(2);
+
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+          matches: false,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        })),
+      });
+
+      const { queryByText } = render(
+        <ClosableBlock
+          headingLevel="h2"
+          heading="heading"
+          body="body"
+          src="https://transferwise.com/public-resources/assets/public-navigation/phone_number.svg"
+        />,
+      );
+
+      const heading = queryByText(/heading/i);
+
+      expect(queryByText(/body/i)).not.toBeVisible();
+
+      fireEvent.click(heading);
+
+      expect(queryByText(/body/i)).toBeVisible();
+    });
+  });
+
+  describe('at large screen sizes', () => {
+    it('cannot be closed', () => {
+      expect.assertions(2);
+
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+          matches: true,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        })),
+      });
+
+      const { queryByText } = render(
+        <ClosableBlock
+          headingLevel="h2"
+          heading="heading"
+          body="body"
+          src="https://transferwise.com/public-resources/assets/public-navigation/phone_number.svg"
+        />,
+      );
+
+      const heading = queryByText(/heading/i);
+
+      expect(queryByText(/body/i)).toBeVisible();
+
+      fireEvent.click(heading);
+
+      expect(queryByText(/body/i)).toBeVisible();
+    });
+  });
+});

--- a/packages/marketing-components/src/closableblock/ClosableBlock.spec.js
+++ b/packages/marketing-components/src/closableblock/ClosableBlock.spec.js
@@ -13,7 +13,9 @@ describe('ClosableBlock', () => {
       value: jest.fn().mockImplementation(() => ({
         matches: false,
         addEventListener: jest.fn(),
+        addListener: jest.fn(),
         removeEventListener: jest.fn(),
+        removeListener: jest.fn(),
       })),
     });
 
@@ -38,7 +40,9 @@ describe('ClosableBlock', () => {
         value: jest.fn().mockImplementation(() => ({
           matches: false,
           addEventListener: jest.fn(),
+          addListener: jest.fn(),
           removeEventListener: jest.fn(),
+          removeListener: jest.fn(),
         })),
       });
 
@@ -70,7 +74,9 @@ describe('ClosableBlock', () => {
         value: jest.fn().mockImplementation(() => ({
           matches: true,
           addEventListener: jest.fn(),
+          addListener: jest.fn(),
           removeEventListener: jest.fn(),
+          removeListener: jest.fn(),
         })),
       });
 

--- a/packages/marketing-components/src/closableblock/ClosableBlock.story.js
+++ b/packages/marketing-components/src/closableblock/ClosableBlock.story.js
@@ -11,11 +11,19 @@ export default {
 
 export const ClosableBlock = () => {
   return (
-    <ClosableBlockComponent
-      headingLevel="h2"
-      heading="Safeguarded at leading banks"
-      body="We keep your money in low-risk financial institutions like JP Morgan Chase, Deutsche Bank, and Barclays."
-      src="https://transferwise.com/public-resources/assets/public-navigation/phone_number.svg"
-    />
+    <div className="storyCSS">
+      <ClosableBlockComponent
+        headingLevel="h2"
+        heading="Safeguarded at leading banks"
+        body="We keep your money in low-risk financial institutions like JP Morgan Chase, Deutsche Bank, and Barclays."
+        src="https://transferwise.com/public-resources/assets/public-navigation/phone_number.svg"
+      />
+      <ClosableBlockComponent
+        headingLevel="h2"
+        heading="Safeguarded at leading banks"
+        body="We keep your money in low-risk financial institutions like JP Morgan Chase, Deutsche Bank, and Barclays."
+        src="https://transferwise.com/public-resources/assets/public-navigation/phone_number.svg"
+      />
+    </div>
   );
 };

--- a/packages/marketing-components/src/closableblock/ClosableBlock.story.js
+++ b/packages/marketing-components/src/closableblock/ClosableBlock.story.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { withKnobs } from '@storybook/addon-knobs';
+
+import ClosableBlockComponent from './ClosableBlock';
+
+export default {
+  component: ClosableBlock,
+  title: 'ClosableBlock',
+  decorators: [withKnobs],
+};
+
+export const ClosableBlock = () => {
+  return (
+    <ClosableBlockComponent
+      headingLevel="h2"
+      heading="Safeguarded at leading banks"
+      body="We keep your money in low-risk financial institutions like JP Morgan Chase, Deutsche Bank, and Barclays."
+      src="https://transferwise.com/public-resources/assets/public-navigation/phone_number.svg"
+    />
+  );
+};

--- a/packages/marketing-components/src/closableblock/index.js
+++ b/packages/marketing-components/src/closableblock/index.js
@@ -1,0 +1,1 @@
+export { default } from './ClosableBlock';

--- a/packages/marketing-components/src/index.js
+++ b/packages/marketing-components/src/index.js
@@ -26,3 +26,4 @@ export {
 export { default as AppStoreBadge } from './appstorebadge';
 export { default as GooglePlayStoreBadge } from './googleplaystorebadge';
 export { default as Link } from './link';
+export { default as ClosableBlock } from './closableblock';

--- a/packages/marketing-components/src/ssr.spec.js
+++ b/packages/marketing-components/src/ssr.spec.js
@@ -38,6 +38,10 @@ describe('Server side rendering', () => {
     href: 'url',
     language: 'language',
     locale: 'locale',
+    src: 'src',
+    heading: 'heading',
+    headingLevel: 'h2',
+    body: 'body',
   };
 
   componentNames.forEach((componentName) => {


### PR DESCRIPTION
## 🖼 Context

On the Money Transfer homepage we have a "Protect your money" section for HAT customers. We want to use this same section on the Multi-currency account homepage. This extracts the component, with fresh CSS and improved accessibility.

## 🚀 Changes

1. Adds the ClosableBlock component
2. Ensure the ClosableBlock component has the matching aria-properties when necessary
2. Ensure the ClosableBlock isn't rendered as a button (or as a focusable element) when the open/close behaviour has been switched off

## 🤔 Considerations

N/A

## ✅ Checklist

- [ ] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/marketing-components/blob/main/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
- [ ] Change has been approved by someone outside of your team
