### PR TITLE
fix(a11y): dismiss the overlay when user presses Esc key

### DIFF
--- a/packages/marketing-components/src/videomodal/VideoModal.js
+++ b/packages/marketing-components/src/videomodal/VideoModal.js
@@ -19,7 +19,11 @@ function VideoModalBody({
   ...rest
 }) {
   return (
-    <AnimatedDialogOverlay style={{ opacity: style.opacity }} className="twmc-video-modal__overlay">
+    <AnimatedDialogOverlay
+      style={{ opacity: style.opacity }}
+      onDismiss={onDismiss}
+      className="twmc-video-modal__overlay"
+    >
       <AnimatedDialogContent
         {...rest}
         style={{


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->

JIRA: https://transferwise.atlassian.net/browse/C20-1389

`@reach/dialog` triggers the `onDismiss` callback on the `DialogOverlay` when a user pressed Esc key. However we don't connect this to our logic for hiding the dialog.

https://reach.tech/dialog/#dialog-ondismiss

## 🚀 Changes

 <!-- What changes have you made? -->

- Connect `onDismiss` on `DialogOverlay` to `onDismiss` from props

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

N/A

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/marketing-components/blob/main/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [ ] Changes work in all supported browsers (don't forget IE11)
- [ ] You've updated the documentation if necessary
- [ ] Change has been approved by someone outside of your team
