### PR TITLE
feat: Add KLFB trust element

### DIFF
--- a/packages/docs/liveEditorCode/trustElements/JPKLFBRegulatedTrustElement.code.js
+++ b/packages/docs/liveEditorCode/trustElements/JPKLFBRegulatedTrustElement.code.js
@@ -1,0 +1,8 @@
+() => (
+  <JPKLFBRegulatedTrustElement
+    title="KLFB regulated"
+    linkText="Learn More"
+    href="https://transferwise.com/jp/terms-of-use-english"
+    useIllustration
+  />
+);

--- a/packages/docs/pages/components/trustElements/JPKLFBRegulatedTrustElement.mdx
+++ b/packages/docs/pages/components/trustElements/JPKLFBRegulatedTrustElement.mdx
@@ -1,0 +1,10 @@
+import { LiveEditorBlock, GeneratePropsTable } from '../../../utils';
+import { JPKLFBRegulatedTrustElement } from '@transferwise/marketing-components';
+import code from '../../../liveEditorCode/trustElements/JPKLFBRegulatedTrustElement.code';
+
+<LiveEditorBlock code={code} scope={{ JPKLFBRegulatedTrustElement }} />
+<GeneratePropsTable componentName="JPKLFBRegulatedTrustElement" />
+
+export const meta = {
+  name: 'JPKLFBRegulatedTrustElement',
+};

--- a/packages/marketing-components/src/index.js
+++ b/packages/marketing-components/src/index.js
@@ -14,6 +14,7 @@ export {
   FSRAApprovedTrustElement,
   InstaMoneyTrustElement,
   JPFSARegulatedTrustElement,
+  JPKLFBRegulatedTrustElement,
   MASRegulatedTrustElement,
   MitsuiTrustElement,
   SafeTrustElement,

--- a/packages/marketing-components/src/trustelements/JPKLFBRegulatedTrustElement/JPKLFBRegulatedTrustElement.js
+++ b/packages/marketing-components/src/trustelements/JPKLFBRegulatedTrustElement/JPKLFBRegulatedTrustElement.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import Types from 'prop-types';
+
+import TrustElement from '../TrustElement';
+import SecurityIllustration from '../SecurityIllustration';
+
+const JPKLFBRegulatedTrustElement = ({ title, linkText, href, useIllustration, ...rest }) => (
+  <TrustElement
+    {...rest}
+    src={<SecurityIllustration />}
+    title={title}
+    linkText={linkText}
+    href={href}
+    shouldAnimate
+    useIllustration={useIllustration}
+  />
+);
+
+JPKLFBRegulatedTrustElement.propTypes = {
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
+  href: Types.string.isRequired,
+  useIllustration: Types.bool,
+};
+
+JPKLFBRegulatedTrustElement.defaultProps = {
+  useIllustration: true,
+};
+
+export default JPKLFBRegulatedTrustElement;

--- a/packages/marketing-components/src/trustelements/JPKLFBRegulatedTrustElement/index.js
+++ b/packages/marketing-components/src/trustelements/JPKLFBRegulatedTrustElement/index.js
@@ -1,0 +1,1 @@
+export { default } from './JPKLFBRegulatedTrustElement';

--- a/packages/marketing-components/src/trustelements/TrustElements.story.js
+++ b/packages/marketing-components/src/trustelements/TrustElements.story.js
@@ -14,6 +14,7 @@ import {
   FSRAApprovedTrustElement,
   InstaMoneyTrustElement,
   JPFSARegulatedTrustElement,
+  JPKLFBRegulatedTrustElement,
   MASRegulatedTrustElement,
   MitsuiTrustElement,
   SafeTrustElement,
@@ -248,6 +249,21 @@ export const JPFSARegulated = () => {
       <div className="col col-xs-offset-5 col-xs-2">
         <JPFSARegulatedTrustElement
           title={text('Title', 'Japanese FSA regulated')}
+          linkText={text('LinkText', 'Learn more')}
+          href={text('Link Url', 'https://transferwise.com/jp/terms-of-use-english')}
+          useIllustration={boolean('useIllustration', true)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const JPKLFBRegulated = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-5 col-xs-2">
+        <JPKLFBRegulatedTrustElement
+          title={text('Title', 'KLFB regulated')}
           linkText={text('LinkText', 'Learn more')}
           href={text('Link Url', 'https://transferwise.com/jp/terms-of-use-english')}
           useIllustration={boolean('useIllustration', true)}

--- a/packages/marketing-components/src/trustelements/index.js
+++ b/packages/marketing-components/src/trustelements/index.js
@@ -11,6 +11,7 @@ export { default as FINTRACRegulatedTrustElement } from './FINTRACRegulatedTrust
 export { default as FSRAApprovedTrustElement } from './FSRAApprovedTrustElement';
 export { default as InstaMoneyTrustElement } from './InstaMoneyTrustElement';
 export { default as JPFSARegulatedTrustElement } from './JPFSARegulatedTrustElement';
+export { default as JPKLFBRegulatedTrustElement } from './JPKLFBRegulatedTrustElement';
 export { default as MASRegulatedTrustElement } from './MASRegulatedTrustElement';
 export { default as MitsuiTrustElement } from './MitsuiTrustElement';
 export { default as SafeTrustElement } from './SafeTrustElement';


### PR DESCRIPTION
## 🖼 Context

We are launching the Japan MCA page and need the "KLFB Regulated" trust element.

## 🚀 Changes

Add the "KLFB Regulated" trust element.

## 🤔 Considerations

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/marketing-components/blob/main/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
- [ ] Change has been approved by someone outside of your team
