### PR TITLE
feat: C20-1477: make ios app store link market agnostic

### DIFF
--- a/packages/docs/liveEditorCode/AppStoreBadge.code.js
+++ b/packages/docs/liveEditorCode/AppStoreBadge.code.js
@@ -1,1 +1,1 @@
-() => <AppStoreBadge locale="gb" language="en" alt="Download from the Apple App Store" />;
+() => <AppStoreBadge language="en" alt="Download from the Apple App Store" />;

--- a/packages/marketing-components/src/appstorebadge/AppStoreBadge.js
+++ b/packages/marketing-components/src/appstorebadge/AppStoreBadge.js
@@ -3,9 +3,8 @@ import Types from 'prop-types';
 
 import './AppStoreBadge.css';
 
-const AppStoreBadge = ({ language, locale, alt, ...rest }) => {
-  const appStoreLocale = locale === 'us' ? 'us' : 'gb';
-  const iosURL = `https://itunes.apple.com/${appStoreLocale}/app/transferwise-money-transfer/id612261027`;
+const AppStoreBadge = ({ language, alt, ...rest }) => {
+  const iosURL = 'https://apps.apple.com/app/id612261027';
 
   return (
     <a {...rest} href={iosURL} target="_blank" rel="noopener noreferrer">
@@ -19,7 +18,6 @@ const AppStoreBadge = ({ language, locale, alt, ...rest }) => {
 };
 
 AppStoreBadge.propTypes = {
-  locale: Types.string.isRequired,
   language: Types.string.isRequired,
   alt: Types.string.isRequired,
 };

--- a/packages/marketing-components/src/appstorebadge/AppStoreBadge.spec.js
+++ b/packages/marketing-components/src/appstorebadge/AppStoreBadge.spec.js
@@ -6,29 +6,20 @@ import AppStoreBadge from './';
 
 describe('AppStoreBadge', () => {
   it('renders', () => {
-    expect(() => render(<AppStoreBadge alt="App Store" locale="us" language="de" />)).not.toThrow();
+    expect(() => render(<AppStoreBadge alt="App Store" language="de" />)).not.toThrow();
   });
 
   it('has a correct App Store url for locale', () => {
-    const { getByAltText } = render(<AppStoreBadge alt="App Store" locale="de" language="de" />);
+    const { getByAltText } = render(<AppStoreBadge alt="App Store" language="de" />);
 
     expect(getByAltText('App Store').closest('a')).toHaveAttribute(
       'href',
-      'https://itunes.apple.com/gb/app/transferwise-money-transfer/id612261027',
-    );
-  });
-
-  it('has a correct App Store url for US locale', () => {
-    const { getByAltText } = render(<AppStoreBadge alt="App Store" locale="us" language="de" />);
-
-    expect(getByAltText('App Store').closest('a')).toHaveAttribute(
-      'href',
-      'https://itunes.apple.com/us/app/transferwise-money-transfer/id612261027',
+      'https://apps.apple.com/app/id612261027',
     );
   });
 
   it('has a correct image', () => {
-    const { getByAltText } = render(<AppStoreBadge alt="App Store" language="pt_PT" locale="us" />);
+    const { getByAltText } = render(<AppStoreBadge alt="App Store" language="pt_PT" />);
 
     expect(getByAltText('App Store')).toHaveAttribute(
       'src',

--- a/packages/marketing-components/src/appstorebadge/AppStoreBadge.story.js
+++ b/packages/marketing-components/src/appstorebadge/AppStoreBadge.story.js
@@ -14,7 +14,6 @@ export const AppStoreBadge = () => {
     <AppStoreBadgeComponent
       language={text('Language', 'en')}
       alt={text('Alt', 'Download from the Apple App Store')}
-      locale={text('Locale', 'gb')}
     />
   );
 };


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->

We want to remove any unnecessary params in app store link and make it market agnostic. Discussion thread: https://transferwise.slack.com/archives/G01FTT1VCGM/p1613395800103500?thread_ts=1613394814.102800&cid=G01FTT1VCGM

https://transferwise.atlassian.net/browse/C20-1473

## 🚀 Changes

 <!-- What changes have you made? -->

- Remove GB/US specific handling

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/marketing-components/blob/main/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
- [ ] Change has been approved by someone outside of your team
