### PR TITLE
feat: C20-1667: Add BrazilianLicenseTrustElement

### DIFF
--- a/packages/docs/liveEditorCode/trustElements/BrazilianLicenseTrustElement.code.js
+++ b/packages/docs/liveEditorCode/trustElements/BrazilianLicenseTrustElement.code.js
@@ -1,0 +1,8 @@
+() => (
+  <BrazilianLicenseTrustElement
+    title="Licence from Brazilian Central Bank"
+    linkText="Learn More"
+    href="https://transferwise.com/help/articles/2Cp4HepKB0xemJ3GwNhRVM"
+    useIllustration
+  />
+);

--- a/packages/docs/pages/components/trustElements/BrazilianLicenseTrustElement.mdx
+++ b/packages/docs/pages/components/trustElements/BrazilianLicenseTrustElement.mdx
@@ -1,0 +1,10 @@
+import { LiveEditorBlock, GeneratePropsTable } from '../../../utils';
+import { BrazilianLicenseTrustElement } from '@transferwise/marketing-components';
+import code from '../../../liveEditorCode/trustElements/BrazilianLicenseTrustElement.code';
+
+<LiveEditorBlock code={code} scope={{ BrazilianLicenseTrustElement }} />
+<GeneratePropsTable componentName="BrazilianLicenseTrustElement" />
+
+export const meta = {
+  name: 'BrazilianLicenseTrustElement',
+};

--- a/packages/marketing-components/src/index.js
+++ b/packages/marketing-components/src/index.js
@@ -5,6 +5,7 @@ export {
   BirlesikOdemeRegulatedTrustElement,
   BNMApprovedTrustElement,
   BrazilianCorrespondentTrustElement,
+  BrazilianLicenseTrustElement,
   CAndEDRegulatedTrustElement,
   CanstarAwardTrustElement,
   CustomersTrustElement,

--- a/packages/marketing-components/src/trustelements/BrazilianLicenseTrustElement/BrazilianLicenseTrustElement.js
+++ b/packages/marketing-components/src/trustelements/BrazilianLicenseTrustElement/BrazilianLicenseTrustElement.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import Types from 'prop-types';
+
+import TrustElement from '../TrustElement';
+
+const BrazilianLicenseTrustElement = ({ title, linkText, href, useIllustration, ...rest }) => (
+  <TrustElement
+    {...rest}
+    src="https://transferwise.com/public-resources/assets/spot-illustrations/banking.svg"
+    title={title}
+    linkText={linkText}
+    href={href}
+    useIllustration={useIllustration}
+  />
+);
+
+BrazilianLicenseTrustElement.propTypes = {
+  title: Types.oneOfType([Types.element, Types.string]).isRequired,
+  linkText: Types.oneOfType([Types.element, Types.string]).isRequired,
+  href: Types.string.isRequired,
+  useIllustration: Types.bool,
+};
+
+BrazilianLicenseTrustElement.defaultProps = {
+  useIllustration: true,
+};
+
+export default BrazilianLicenseTrustElement;

--- a/packages/marketing-components/src/trustelements/BrazilianLicenseTrustElement/index.js
+++ b/packages/marketing-components/src/trustelements/BrazilianLicenseTrustElement/index.js
@@ -1,0 +1,1 @@
+export { default } from './BrazilianLicenseTrustElement';

--- a/packages/marketing-components/src/trustelements/TrustElements.story.js
+++ b/packages/marketing-components/src/trustelements/TrustElements.story.js
@@ -5,6 +5,7 @@ import {
   BirlesikOdemeRegulatedTrustElement,
   BNMApprovedTrustElement,
   BrazilianCorrespondentTrustElement,
+  BrazilianLicenseTrustElement,
   CAndEDRegulatedTrustElement,
   CanstarAwardTrustElement,
   CustomersTrustElement,
@@ -92,6 +93,21 @@ export const BrazilianCorrespondent = () => {
           title={text('Title', 'Acting as exchange correspondents of Brazilian banks')}
           linkText={text('LinkText', 'Learn more')}
           href={text('Link Url', 'https://transferwise.com/br#br-partners')}
+          useIllustration={boolean('useIllustration', true)}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const BrazilianLicense = () => {
+  return (
+    <div className="row">
+      <div className="col col-xs-offset-5 col-xs-2">
+        <BrazilianLicenseTrustElement
+          title={text('Title', 'Licence from Brazilian Central Bank')}
+          linkText={text('LinkText', 'Learn more')}
+          href={text('Link Url', 'https://transferwise.com/help/articles/2Cp4HepKB0xemJ3GwNhRVM')}
           useIllustration={boolean('useIllustration', true)}
         />
       </div>

--- a/packages/marketing-components/src/trustelements/index.js
+++ b/packages/marketing-components/src/trustelements/index.js
@@ -2,6 +2,7 @@ export { default as ASICRegulatedTrustElement } from './ASICRegulatedTrustElemen
 export { default as BirlesikOdemeRegulatedTrustElement } from './BirlesikOdemeRegulatedTrustElement';
 export { default as BNMApprovedTrustElement } from './BNMApprovedTrustElement';
 export { default as BrazilianCorrespondentTrustElement } from './BrazilianCorrespondentTrustElement';
+export { default as BrazilianLicenseTrustElement } from './BrazilianLicenseTrustElement';
 export { default as CAndEDRegulatedTrustElement } from './CAndEDRegulatedTrustElement';
 export { default as CanstarAwardTrustElement } from './CanstarAwardTrustElement';
 export { default as CustomersTrustElement } from './CustomersTrustElement';


### PR DESCRIPTION
## 🖼 Context

<!-- Why is this PR necessary? Please include links to mockups, JIRA ticket or other relevant documentation. -->

https://transferwise.atlassian.net/browse/C20-1667

We need the Brazilian license trust element on MCA. On homepage its hardcoded in the repo. For MCA, we use trust elements from here.

## 🚀 Changes

 <!-- What changes have you made? -->

- Add new trust element: `BrazilianLicenseTrustElement`
- Update docs and storybook
- Icon is reused from static-assets

## 🤔 Considerations

<!-- Anything else we should keep in mind? -->

N/A

## ✅ Checklist

- [x] Make PR title meaningful and follow [the commit lint format](https://github.com/transferwise/marketing-components/blob/main/CONTRIBUTING.md#versioning-and-commit-lint) (it will appear in the changelog)
- [x] Changes are tested and all tests pass
- [x] Changes meet [accessibility standards](https://github.com/transferwise/marketing-components/blob/main/ACCESSIBILITY.md) and there are no violations in the console
- [x] Changes work in all supported browsers (don't forget IE11)
- [x] You've updated the documentation if necessary
- [x] Change has been approved by someone outside of your team
